### PR TITLE
Review20200224

### DIFF
--- a/specificatie/BRK-Bevragen/openapi.yaml
+++ b/specificatie/BRK-Bevragen/openapi.yaml
@@ -35,7 +35,7 @@ paths:
               -  huisletter (optioneel)
               -  huisnummertoevoeging (optioneel)
 
-          Met gebruik van de parameter expand kunnen gerelateerde zakelijkgerechtigden direct worden meegeladen.
+          Met gebruik van de parameter expand kunnen zakelijkgerechtigden direct worden meegeladen.
 
           Het maximale aantal zoekresultaten dat geretourneerd wordt is aan de provider om te bepalen. Als het resultaat van de de request dit aantal overtreft worden er geen resultaten geretourneerd en volgt er een foutmelding.
       parameters:
@@ -167,7 +167,7 @@ paths:
       description: |
         Het ophalen van een Kadastraal Onroerende zaak.
 
-        Met gebruik van de parameter expand kunnen gerelateerde zakelijkgerechtigden direct worden meegeladen.
+        Met gebruik van de parameter expand kunnen zakelijkgerechtigden direct worden meegeladen.
       parameters:
         - in: path
           name: kadastraalobjectidentificatie

--- a/specificatie/BRK-Bevragen/openapi.yaml
+++ b/specificatie/BRK-Bevragen/openapi.yaml
@@ -1818,7 +1818,7 @@ In een stuk is daarom óf een kadasterstuk óf een terInschrijvingAangebodenStuk
           minItems: 1
           items:
             $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
-        zakelijkGerechtigde:
+        zakelijkGerechtigden:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
 #        nietBagAdressen:
 #          title: "betreft"
@@ -1883,7 +1883,7 @@ In een stuk is daarom óf een kadasterstuk óf een terInschrijvingAangebodenStuk
           title: "rustOp"
           type: "array"
           items:
-            $ref: "#/components/schemas/ZakelijkGerechtigde"
+            $ref: "#/components/schemas/ZakelijkGerechtigdeHal"
     TypeKadastraalOnroerendeZaak_enum:
       type: "string"
       enum:

--- a/specificatie/BRK-Bevragen/openapi.yaml
+++ b/specificatie/BRK-Bevragen/openapi.yaml
@@ -1063,7 +1063,7 @@ components:
           $ref: "#/components/schemas/TypePerceelnummerVerschuiving"
         nummeraanduidingIdentificatie:
           type: "string"
-          description: "Dit element is de identificatie van het bagAdres. Dit om zelf de URL op te stellen of om in te vullen in de tamplated HAL-linK naar de BAG."
+          description: "Dit element is de identificatie van het bagAdres. Dit om zelf de URL op te stellen of om in te vullen in de templated HAL-linK naar de BAG."
         stukIdentificatie:
           type: "array"
           description: "Dit element is de identificatie van het Stuk. Dit kan een aangeboden Stuk of een Kadasterstuk zijn."

--- a/specificatie/BRK-Bevragen/openapi.yaml
+++ b/specificatie/BRK-Bevragen/openapi.yaml
@@ -17,8 +17,8 @@ paths:
     get:
       operationId: GetKadastraalOnroerendeZaken
       description: |
-          Het ophalen van een collectie Kadastraal Onroerende zaken. 
-          Ten minste één van de volgende combinaties van parameters moet zijn opgenomen 
+          Het ophalen van een collectie Kadastraal Onroerende zaken.
+          Ten minste één van de volgende combinaties van parameters moet zijn opgenomen
           1.  Kadastrale aanduiding
               -  kadastrale_gemeente (verplicht)
               -  perceelnummer (verplicht)
@@ -26,25 +26,27 @@ paths:
               -  appartementsrechtnummer (optioneel)
           2.  Ingeschreven persoon als zakelijk gerechtigde
               -  burgerservicenummer
-          3.  Niet ingeschreven persoon of niet natuurlijk persoon als zakelijk gerechtigde 
+          3.  Niet ingeschreven persoon of niet natuurlijk persoon als zakelijk gerechtigde
               -  kadastraalpersoonidentificatie
               -  typegerechtigde
           4.  Adres
               -  postcode (verplicht)
-              -  huisnummer (optioneel) 
+              -  huisnummer (optioneel)
               -  huisletter (optioneel)
               -  huisnummertoevoeging (optioneel)
 
-          Het maximale aantal zoekresultaten dat geretourneerd wordt is aan de provider om te bepalen. Als het resultaat van de de request dit aantal overtreft worden er geen resultaten geretourneerd en volgt er een foutmelding."
-      parameters: 
+          Met gebruik van de parameter expand kunnen gerelateerde zakelijkgerechtigden direct worden meegeladen.
+
+          Het maximale aantal zoekresultaten dat geretourneerd wordt is aan de provider om te bepalen. Als het resultaat van de de request dit aantal overtreft worden er geen resultaten geretourneerd en volgt er een foutmelding.
+      parameters:
         - $ref: "https://cdn.jsdelivr.net/gh/geonovum/kp-api-guidelines@1.0.0/components/parameters.yaml#/acceptCrs"
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/expand"
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: query
           name: kadastralegemeente__code
           description: "De code van de kadastrale gemeente, deel van de kadastrale aanduiding van de onroerende zaak. De code en waarde zijn vastgelegd in een [Waardelijst](http://www.kadaster.nl/schemas/waardelijsten/KadastraleGemeente/)"
-          schema: 
-            type: "string"  
+          schema:
+            type: "string"
             example: "50"
         - in: query
           name: perceelnummer
@@ -70,7 +72,7 @@ paths:
           name: appartementsrechtvolgnummer
           description: "Nummer dat het kadastraal object uniek identificeert als een\
             \ appartementsrecht binnen het complex."
-          schema: 
+          schema:
             type: "integer"
         - in: query
           name: burgerservicenummer
@@ -87,38 +89,38 @@ paths:
             type: string
         - in: query
           name: typegerechtigde
-          description: "Een typering van het recht dat de zakelijkgerechtigde heeft op de Kadastraal Onroerende Zaak. De mogelijke waarden van deze typering is te vinden in een [waardelijst] __***(Hier nog de locatie van de betreffende waardelijst toevoegen !***__  . We gebruiken de **code** can de waardelijst als parameter. Door het gebruik van deze query-parameter worden Kadastraal Onroerende Zaken geretourneerd waar een recht op rust van het opgegeven type. "
+          description: "Een typering van het recht dat de zakelijkgerechtigde heeft op de Kadastraal Onroerende Zaak. Door het gebruik van deze query-parameter worden Kadastraal Onroerende Zaken geretourneerd waar een recht op rust van het opgegeven type."
           required: false
           schema:
-            type: integer
+            $ref: "#/components/schemas/typeGerechtigde_enum"
         - in: query
           name: postcode
           description: "De postcode van het adres van de objectlocatie van de kadastraal onroerende zaak"
           required: false
-          schema: 
+          schema:
             type: string
-            pattern: "^[1-9][0-9][0-9][0-9][A-Z][A-Z]$" 
+            pattern: "^[1-9][0-9][0-9][0-9][A-Z][A-Z]$"
         - in: query
           name: huisnummer
           description: "Het huisnummer van het adres van de objectlocatie van de kadastraal onroerende zaak"
           required: false
-          schema: 
+          schema:
             type: integer
-            pattern: "^[1-9][0-9]{0,4}$" 
+            pattern: "^[1-9][0-9]{0,4}$"
         - in: query
           name: huisletter
           description: "De huisletter van het adres van de objectlocatie van de kadastraal onroerende zaak"
           required: false
-          schema: 
+          schema:
             type: string
-            pattern: "^[a-zA-Z]$" 
+            pattern: "^[a-zA-Z]$"
         - in: query
           name: huisnummertoevoeging
           description: "De huisnummertoevoeging van het adres van de objectlocatie van de kadastraal onroerende zaak"
           required: false
-          schema: 
+          schema:
             type: string
-            pattern: "^([a-z,A-Z,0-9])+$" 
+            pattern: "^([a-z,A-Z,0-9])+$"
       responses:
         '200':
           description: "Zoekactie geslaagd"
@@ -157,13 +159,16 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
         '503':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
-      tags: 
+      tags:
       - Kadastraal Onroerende Zaken
   /kadastraalonroerendezaken/{kadastraalobjectidentificatie}:
     get:
       operationId: GetKadastraalOnroerendeZaak
-      description: "Het ophalen van een Kadastraal Onroerende zaak."
-      parameters: 
+      description: |
+        Het ophalen van een Kadastraal Onroerende zaak.
+
+        Met gebruik van de parameter expand kunnen gerelateerde zakelijkgerechtigden direct worden meegeladen.
+      parameters:
         - in: path
           name: kadastraalobjectidentificatie
           description: "Kadastrale aanduiding is de unieke aanduiding van een onroerende zaak, die door het kadaster wordt vastgesteld. Kadastrale aanduiding is de unieke aanduiding van een onroerende zaak, die door het kadaster wordt vastgesteld. Toelichting : In de tijd gezien kan dezelfde onroerende zaak wel meerdere kadastrale aanduidingen hebben, te weten in het geval dat er een herindeling plaatsvindt."
@@ -213,13 +218,13 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
         '503':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
-      tags: 
+      tags:
       - Kadastraal Onroerende Zaken
   /kadastraalonroerendezaken/{kadastraalobjectidentificatie}/zakelijkgerechtigden:
     get:
       operationId: GetZakelijkGerechtigden
       description: "Het ophalen van een de zakelijke gerechtigden behorende bij een Kadastraal Onroerende Zaak. Aandeel wordt altijd geleverd in combinatie met het gezamenlijk aandeel."
-      parameters: 
+      parameters:
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: path
           name: kadastraalobjectidentificatie
@@ -229,10 +234,10 @@ paths:
             type: string
         - in: query
           name: typegerechtigde
-          description: "Een typering van het recht dat de zakelijkgerechtigde heeft op de Kadastraal Onroerende Zaak. De mogelijke waarden van deze typering is te vinden in een [waardelijst] __***(Hier nog de locatie van de betreffende waardelijst toevoegen !***__  . We gebruiken de **code** can de waardelijst als parameter. Door het gebruik van deze query-parameter worden Kadastraal Onroerende Zaken geretourneerd waar een recht op rust van het opgegeven type. "
+          description: "Een typering van het recht dat de zakelijkgerechtigde heeft op de Kadastraal Onroerende Zaak."
           required: false
           schema:
-            type: string
+            $ref: "#/components/schemas/typeGerechtigde_enum"
       responses:
         '200':
           description: "Zoekactie geslaagd"
@@ -273,13 +278,13 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
         '503':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
-      tags: 
+      tags:
       - Zakelijke Gerechtigden
   /kadasternatuurlijkpersonen/{identificatie}:
     get:
       operationId: GetKadasterPersoon
       description: "Het ophalen van een bij het Kadaster geregistreerd Natuurlijk Persoon, niet zijnde een ingeschreven natuurlijk persoon."
-      parameters: 
+      parameters:
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/expand"
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: path
@@ -329,13 +334,13 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
         '503':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
-      tags: 
+      tags:
       - Kadaster (niet)Natuurlijk Personen
   /kadasternietnatuurlijkpersonen/{identificatie}:
     get:
       operationId: GetKadasterNietNatuurlijkPersoon
       description: "Het ophalen van een bij het Kadaster geregistreerd niet natuurlijk Persoon, niet zijnde een ingeschreven niet natuurlijk persoon."
-      parameters: 
+      parameters:
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/expand"
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: path
@@ -385,13 +390,13 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
         '503':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
-      tags: 
-      - Kadaster (niet)Natuurlijk Personen 
+      tags:
+      - Kadaster (niet)Natuurlijk Personen
   /kadasternatuurlijkpersonen:
     get:
       operationId: GetKadasterPersonen
       description: "Het ophalen van een collectie bij het Kadaster geregistreerd Natuurlijk Personen, niet zijnde ingeschreven natuurlijk personen."
-      parameters: 
+      parameters:
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/expand"
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: query
@@ -440,13 +445,13 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
         '503':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
-      tags: 
+      tags:
       - Kadaster (niet)Natuurlijk Personen
   /kadasternietnatuurlijkpersonen:
     get:
       operationId: GetKadasterNietNatuurlijkPersonen
       description: "Het ophalen van een collectie bij het Kadaster geregistreerde niet natuurlijk Personen, niet zijnde ingeschreven niet natuurlijk personen."
-      parameters: 
+      parameters:
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/expand"
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: query
@@ -495,13 +500,13 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
         '503':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
-      tags: 
-      - Kadaster (niet)Natuurlijk Personen 
+      tags:
+      - Kadaster (niet)Natuurlijk Personen
   /stukken/{identificatie}:
     get:
       operationId: GetStuk
       description: "In een akte (stuk) zijn meerdere rechtsfeiten (stukdelen) vastgelegd. De rechtsfeiten zijn gestructureerd vastglegd in stukdelen en deze stukdelen verwijzen naar de akte. Het is dus mogelijk om met verschillende stukdeel-identificaties dezelfde akte op te vragen. Daarnaast zijn er twee typen aktes die geretourneerd kunnen worden. Een aangeboden stuk of een kadasterstuk."
-      parameters: 
+      parameters:
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/expand"
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: path
@@ -551,13 +556,13 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
         '503':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
-      tags: 
-      - Aangeboden Stukken (Akte) 
+      tags:
+      - Aangeboden Stukken (Akte)
   /kadastraalonroerendezaken/{kadastraalobjectidentificatie}/privaatrechtelijkebeperkingen:
     get:
       operationId: GetPrivaatrechtelijkeBeperkingKadastraalonroerendezaak
       description: "Het ophalen van privaatrechtelijke beperkingen die bij een kadastraal onroerende zaak horen. "
-      parameters: 
+      parameters:
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: path
           name: kadastraalobjectidentificatie
@@ -605,13 +610,13 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
         '503':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
-      tags: 
+      tags:
       - Privaatrechtelijke Beperkingen
   /kadastraalonroerendezaken/{kadastraalobjectidentificatie}/hypotheken:
     get:
       operationId: GetHypothekenKadastraalOnroerendeZaak
       description: "Het ophalen van hypotheken en hypotheeknemers van een specifieke kadastraal onroerende zaak."
-      parameters: 
+      parameters:
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: path
           name: kadastraalobjectidentificatie
@@ -659,13 +664,13 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
         '503':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
-      tags: 
+      tags:
       - Hypotheken
   /hypotheken:
     get:
       operationId: GetHypotheken
       description: "Het ophalen van hypotheken van een specifieke hypotheekhouder die als geldverstrekker een recht van hypotheek vestigt als zekerheid voor de lening."
-      parameters: 
+      parameters:
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: query
           name: burgerservicenummer
@@ -720,13 +725,13 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
         '503':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
-      tags: 
+      tags:
       - Hypotheken
   /kadastraalonroerendezaken/{kadastraalobjectidentificatie}/beslagen:
     get:
       operationId: GetBeslagenKadastraalOnroerendeZaak
       description: "Het ophalen van beslagen en beslagleggers van een specifieke Kadastraal Onroerende Zaak."
-      parameters: 
+      parameters:
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: path
           name: kadastraalobjectidentificatie
@@ -774,21 +779,21 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
         '503':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
-      tags: 
+      tags:
       - Beslagen
   /beslagen:
     get:
       operationId: GetBeslagen
       description: |
-          Het ophalen van beslagen die door een specifieke beslaglegger zijn gelegd. 
-          Ten minste één van de volgende combinaties van parameters moet zijn opgenomen 
+          Het ophalen van beslagen die door een specifieke beslaglegger zijn gelegd.
+          Ten minste één van de volgende combinaties van parameters moet zijn opgenomen
           1.  Beslaglegger is een Persoon die bekend is in de BRP als ingeschreven persoon
               -  burgerservicenummer (verplicht)
               -  typepersoon (verplicht)
           2.  Beslaglegger is niet bekend als ingeschreven persoon in de BRP of de beslaglegger is een rechtspersoon
               -  kadasterpersoonidentificatie (verplicht)
               -  typepersoon (verplicht)
-      parameters: 
+      parameters:
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/parameters/fields"
         - in: query
           name: burgerservicenummer
@@ -807,8 +812,9 @@ paths:
           name: typepersoon
           description: "Met dit type wordt aangegeven of het een Persoon uit de Basisregistratie Personen (ingeschrevenpersoon) betreft danwel een persoon die door het kadaster wordt geregistreerd (kadasterpersoon). Een kadasterpersoon kan een persoon zijn die niet in de BRP bekend is of een Rechtspersoon."
           required: true
-          schema: 
-            $ref: "#/components/schemas/TypePersoon_enum"
+          schema:
+            type: string
+            maxLength: 15
       responses:
         '200':
           description: "Zoekactie geslaagd"
@@ -849,7 +855,7 @@ paths:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/500"
         '503':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/responses/503"
-      tags: 
+      tags:
       - Beslagen
 components:
   schemas:
@@ -860,10 +866,10 @@ components:
           type: string
         type:
           type: string
-    Aantekening: 
+    Aantekening:
       type: "object"
       properties:
-        identificatie: 
+        identificatie:
           type: "string"
         aardAantekening:
           allOf:
@@ -871,13 +877,13 @@ components:
           - description: "Mogelijke waarden zijn te vinden in deze [Waardelijst](http://www.kadaster.nl/schemas/waardelijsten/AardAantekening/)"
         omschrijving:
           type: "string"
-        begrenzing: 
+        begrenzing:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/Geometry"
         begrenzingDienendErf:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/Geometry"
         begrenzingHeersendErf:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/Geometry"
-        einddatum: 
+        einddatum:
           type: "string"
           format: "date"
         eindatumRecht:
@@ -910,18 +916,18 @@ components:
           properties:
             privaatrechtelijkeBeperkingen:
               type: "array"
-              items: 
+              items:
                 $ref: "#/components/schemas/PrivaatrechtelijkeBeperkingHal"
-    Beslag: 
+    Beslag:
       type: "object"
       properties:
-        identificatie: 
+        identificatie:
           type: "string"
         aandeelInBetrokkenRecht:
           $ref: "#/components/schemas/TypeBreuk"
         gedeeltelijkeBezwaringOudObject:
           type: "boolean"
-        omschrijvingBetrokkenRecht: 
+        omschrijvingBetrokkenRecht:
           allOf:
           - $ref: "#/components/schemas/Waardelijst"
           - description: "Mogelijke waarden zijn te vinden in deze [Waardelijst](http://www.kadaster.nl/schemas/waardelijsten/BetrokkenRecht/)"
@@ -945,7 +951,7 @@ components:
       - properties:
           _links:
             $ref: "#/components/schemas/Beslag_links"
-    BeslagHalCollectie: 
+    BeslagHalCollectie:
       type: "object"
       properties:
         _links:
@@ -955,22 +961,22 @@ components:
           properties:
             beslagen:
               type: "array"
-              items: 
+              items:
                 $ref: "#/components/schemas/BeslagHal"
     Beslaglegger:
       allOf:
-        - description: "Dit element is opgenomen om de identificatie van de beslaglegger beschikbaar te stellen voor partijen die geen gebruik willen maken van de HalLinks voor een verwijzing naar een resource buiten het domein van deze API"
         - $ref: "#/components/schemas/ResourceIdentificatie"
-    Hypotheek: 
+        - description: "Dit element is opgenomen om de identificatie van de beslaglegger beschikbaar te stellen voor partijen die geen gebruik willen maken van de HalLinks voor een verwijzing naar een resource buiten het domein van deze API"
+    Hypotheek:
       type: "object"
       properties:
-        identificatie: 
+        identificatie:
           type: "string"
         aandeelInBetrokkenRecht:
           $ref: "#/components/schemas/TypeBreuk"
         gedeeltelijkeBezwaringOudObject:
           type: "boolean"
-        omschrijvingBetrokkenRecht: 
+        omschrijvingBetrokkenRecht:
           allOf:
           - $ref: "#/components/schemas/Waardelijst"
           - description: "Mogelijke waarden zijn te vinden in deze [Waardelijst](http://www.kadaster.nl/schemas/waardelijsten/BetrokkenRecht/)"
@@ -993,7 +999,7 @@ components:
       - properties:
           _links:
             $ref: "#/components/schemas/Hypotheek_links"
-    HypotheekHalCollectie: 
+    HypotheekHalCollectie:
       type: "object"
       properties:
         _links:
@@ -1003,7 +1009,7 @@ components:
           properties:
             hypotheken:
               type: "array"
-              items: 
+              items:
                 $ref: "#/components/schemas/HypotheekHal"
     KadastraalOnroerendeZaak:
       type: "object"
@@ -1012,7 +1018,7 @@ components:
       properties:
         kadastraalObjectIdentificatie:
           description: "Dit is de unieke identificatie van een kadastraal object. "
-          type: "string" 
+          type: "string"
         begrenzingPerceel:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/Geometry"
         omschrijvingOnderzoekErfdienstbaarheden:
@@ -1057,7 +1063,7 @@ components:
           $ref: "#/components/schemas/TypePerceelnummerVerschuiving"
         nummeraanduidingIdentificatie:
           type: "string"
-          description: "Dit element is de identificatie van het bagAdres. Dit om zelf de URL op te stellen of om in te vullen in de tamplated Halling naar de BAG."
+          description: "Dit element is de identificatie van het bagAdres. Dit om zelf de URL op te stellen of om in te vullen in de tamplated HAL-linK naar de BAG."
         stukIdentificatie:
           type: "array"
           description: "Dit element is de identificatie van het Stuk. Dit kan een aangeboden Stuk of een Kadasterstuk zijn."
@@ -1081,7 +1087,7 @@ components:
           properties:
             kadastraalOnroerendeZaken:
               type: "array"
-              items: 
+              items:
                 $ref: "#/components/schemas/KadastraalOnroerendeZaakHal"
     KadasterNatuurlijkPersoon:
       allOf:
@@ -1129,7 +1135,7 @@ components:
           properties:
             kadasterNatuurlijkPersonen:
               type: "array"
-              items: 
+              items:
                 $ref: "#/components/schemas/KadasterNatuurlijkPersoonHal"
     KadasterNietNatuurlijkPersoon:
       allOf:
@@ -1167,13 +1173,13 @@ components:
           properties:
             kadasterNietNatuurlijkPersonen:
               type: "array"
-              items: 
+              items:
                 $ref: "#/components/schemas/KadasterNietNatuurlijkPersoonHal"
     Hypotheek_links:
       type: "object"
       properties:
         hypotheekhouder:
-          title: "isHypotheekhouder"     
+          title: "isHypotheekhouder"
           type: "object"
           description: "Dit is een natuurlijk persoon of een niet-natuurlijk persoon die als geldverstrekker een recht van hypotheek vestigt als zekerheid voor de lening."
           properties:
@@ -1233,8 +1239,7 @@ components:
       type: object
       properties:
         typeGerechtigde:
-          type: "string"
-          description: "Het type zakelijk recht dat deze gerechtigde heeft."
+          $ref: "#/components/schemas/typeGerechtigde_enum"
         aanvangsdatum:
           type: "string"
           description: "Datum waarop het zakelijk recht van kracht is geworden. "
@@ -1248,7 +1253,7 @@ components:
           description: "Dit element is de identificatie van het Stuk. Dit kan een aangeboden Stuk of een Kadasterstuk zijn."
           items:
             $ref: "#/components/schemas/ResourceIdentificatie"
-        persoon: 
+        persoon:
           $ref: "#/components/schemas/ResourceIdentificatie"
     ZakelijkGerechtigdeHal:
       allOf:
@@ -1266,33 +1271,36 @@ components:
           properties:
             zakelijkGerechtigden:
               type: "array"
-              items: 
+              items:
                 $ref: "#/components/schemas/ZakelijkGerechtigdeHal"
     Tenaamstelling:
       type: object
+      description: "Een tenaamstelling is een registratie van (een aandeel in) een zakelijk recht dat een persoon heeft, dat rust op een kadastraal object.\n
+      De tenaamstelling is ten name één van de volgende soorten persoon: kadasterNatuurlijkPersoon, kadasterNietNatuurlijkPersoon, ingeschrevenNatuurlijkPersoon, ingeschrevenNietNatuurlijkPersoon."
       properties:
         aandeel:
           $ref: "#/components/schemas/TypeBreuk"
-        burgerlijkeStaatTenTijdeVanVerkrijging: 
+        burgerlijkeStaatTenTijdeVanVerkrijging:
           allOf:
           - $ref: "#/components/schemas/Waardelijst"
           - description: "Mogelijke waarden zijn te vinden in deze [Waardelijst](http://www.kadaster.nl/schemas/waardelijsten/BurgerlijkeStaat/)"
         verkregenNamensSamenwerkingsverband:
            $ref: "#/components/schemas/Waardelijst"
-        aantekening: 
+        aantekening:
           $ref: "#/components/schemas/Aantekening"
         gezamenlijkAandeel:
           $ref: "#/components/schemas/TypeBreuk"
-        persoon:
-          discriminator:
-            propertyName: persoonType
-          oneOf:
-#         - $ref: '#/components/schemas/AbstractPersoonCompact'    Nodig om de juiste code te genereren.
-          - $ref: '#/components/schemas/NatuurlijkPersoonCompact'
-          - $ref: '#/components/schemas/NietNatuurlijkPersoonCompact'
+        kadasterNatuurlijkPersoon:
+          $ref: '#/components/schemas/NatuurlijkPersoonCompact'
+        kadasterNietNatuurlijkPersoon:
+          $ref: '#/components/schemas/NietNatuurlijkPersoonCompact'
+        ingeschrevenNatuurlijkPersoon:
+          $ref: '#/components/schemas/IngeschrevenNatuurlijkPersoonCompact'
+        ingeschrevenNietNatuurlijkPersoon:
+          $ref: '#/components/schemas/IngeschrevenNietNatuurlijkPersoonCompact'
     AbstractPersoonCompact:
       type: object
-      description: "Deze constructie is toegevoegd om te voorkomen dat het persoon-element uittenaamstelling met een oneOf zou moeten worden gedefinieerd. Dat levert problemen op bij codegeneratie. "
+      description: ""
       properties:
         identificatie:
           title: identificatie
@@ -1311,6 +1319,24 @@ components:
       - properties:
           actueleStatutaireNaam:
             type: string
+    IngeschrevenNatuurlijkPersoonCompact:
+      type: object
+      description: "Natuurlijk persoon ingeschreven in de Basisregistratie Personen (BRP) met een burgerservicenummer"
+      properties:
+        burgerservicenummer:
+          type: string
+        naam:
+          type: string
+        geboortedatum:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/Datum_onvolledig"
+    IngeschrevenNietNatuurlijkPersoonCompact:
+      type: object
+      description: "Niet-natuurlijk persoon ingeschreven in het Handelsregister"
+      properties:
+        rsin:
+          type: string
+        naam:
+          type: string
     Objectlocatiebuitenland:
       allOf:
       - $ref: "#/components/schemas/Objectlocatie"
@@ -1476,14 +1502,6 @@ components:
             description: ""
           acgIdentificatie:
             $ref: "#/components/schemas/AcgID"
-          identificatie:
-            type: "string"
-    KadasterStukHal:
-      allOf:
-      - $ref: "#/components/schemas/KadasterStuk"
-      - properties:
-          _links:
-            $ref: "#/components/schemas/KadasterStuk_links"
     AangebodenStuk:
       allOf:
       - $ref: "#/components/schemas/AbstractStuk"
@@ -1514,8 +1532,6 @@ components:
             - description: "Mogelijke waarden zijn te vinden in deze [Waardelijst](http://www.kadaster.nl/schemas/waardelijsten/AardAangebodenStuk/)"
           deelEnNummer:
             $ref: "#/components/schemas/TypeDeelEnNummer"
-          identificatie:
-            type: "string"
           statusStukOr:
             allOf:
             - $ref: "#/components/schemas/Waardelijst"
@@ -1524,14 +1540,6 @@ components:
             $ref: "#/components/schemas/HeeftAlsEquivalentieVerklaarder"
           ondertekenaar:
             $ref: "#/components/schemas/Ondertekenaar"
-    AangebodenStukHal:
-      allOf:
-      - $ref: "#/components/schemas/AangebodenStuk"
-      - properties:
-          _links:
-            $ref: "#/components/schemas/AangebodenStuk_links"
-          _embedded:
-            $ref: "#/components/schemas/AangebodenStuk_embedded"
     Kadasterverzoek:
       type: "object"
       description: "uri https://tax.kadaster.nl/doc/begrip/Kadaster_verzoek"
@@ -1617,7 +1625,7 @@ components:
         kadastraleGemeente:
           allOf:
             - description: "De kadastrale gemeente, deel van de kadastrale aanduiding van de onroerende zaak. De waarden komen uit een Waardelijst( http://www.kadaster.nl/schemas/waardelijsten/KadastraleGemeente). Elke kadastrale gemeentenaam is uniek."
-            - $ref: "#/components/schemas/Waardelijst"  
+            - $ref: "#/components/schemas/Waardelijst"
         perceelnummer:
           type: "integer"
           title: "perceelnummer"
@@ -1708,7 +1716,9 @@ components:
         metNaamOpenbaarRegister:
           type: "array"
           items:
-            $ref: "#/components/schemas/MetNaamOpenbaarRegister"
+            type: "string"
+            title: "naam"
+            maxLength: 320
     Objectlocatie:
       allOf:
       - $ref: "#/components/schemas/Adreslocatie"
@@ -1720,21 +1730,35 @@ components:
         identificatie:
           type: "string"
     StukHal:
-      oneOf: 
-#       - $ref: "#/components/schemas/AbstractStuk"   Nodig voor het correct genereren van code. 
-        - $ref: "#/components/schemas/AangebodenStukHal"
-        - $ref: "#/components/schemas/KadasterStukHal"
-      discriminator:
-        propertyName: stukType
+      type: object
+      description: "Een stuk is een document waaruit een wijziging in de BRK blijkt.\n
+      Er zijn 2 soorten stukken: \n
+* Een ter inschrijving in de openbare registers aangeboden stuk en \n
+* een door het Kadaster opgemaakt stuk.
+\n \n
+In een stuk is daarom óf een kadasterstuk óf een terInschrijvingAangebodenStuk opgenomen."
+      properties:
+        kadasterstuk:
+          $ref: "#/components/schemas/KadasterStuk"
+        terInschrijvingAangebodenStuk:
+          $ref: "#/components/schemas/AangebodenStuk"
+        _links:
+          $ref: "#/components/schemas/Stuk_links"
+        _embedded:
+          $ref: "#/components/schemas/AangebodenStuk_embedded"
+
     AbstractStuk:
       type: "object"
       description: "Een stuk is een, door het Kadaster als authentiek erkend, document\
-        \ waaruit een wijziging in de BRK blijkt. Hier wordt een Kadasterstuk of een Aangebodenstuk aan gekoppeld. De OneOf levert hier genreer-problemen op en is dus niet opgenomen in deze YAML. Als deze genereer-problemen opgelost zijn wordt dit herzien. "
+        \ waaruit een wijziging in de BRK blijkt. Hier wordt een Kadasterstuk of een Aangebodenstuk aan gekoppeld."
       properties:
+        identificatie:
+          type: "string"
+          description: "Uniek nummer van het object binnen de kadastrale registratie"
         toelichtingBewaarder:
           type: "string"
           title: "toelichtingBewaarder"
-          description: ""
+          description: "Toelichtende tekst bij een onroerende zaak toegevoegd door de bewaarder"
     Objectlocatiebuitenland_links:
       type: "object"
       properties:
@@ -1750,12 +1774,7 @@ components:
       properties:
         self:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
-    KadasterStuk_links:
-      type: "object"
-      properties:
-        self:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
-    AangebodenStuk_links:
+    Stuk_links:
       type: "object"
       properties:
         self:
@@ -1799,13 +1818,8 @@ components:
           minItems: 1
           items:
             $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
-        zakelijkGerechtigden:
-          title: "heeft"
-          type: "array"
-          description: ""
-          minItems: 1
-          items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
+        zakelijkGerechtigde:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
 #        nietBagAdressen:
 #          title: "betreft"
 #          type: "array"            Is geen endpoint voor Komt te vervallen ?
@@ -1839,7 +1853,7 @@ components:
           title: ""
           type: "array"
           items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"  
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/HalLink"
     Persoon_embedded:
       type: "object"
       properties:
@@ -1868,33 +1882,58 @@ components:
         zakelijkGerechtigden:
           title: "rustOp"
           type: "array"
-          description: ""
-          minItems: 1
           items:
             $ref: "#/components/schemas/ZakelijkGerechtigde"
-        aantekening:
-          $ref: "#/components/schemas/Aantekening"
     TypeKadastraalOnroerendeZaak_enum:
       type: "string"
-      description: ":\n* `appartementsrecht` - appartementsrecht\n* `perceel` - perceel"
       enum:
       - "appartementsrecht"
       - "perceel"
+    typeGerechtigde_enum:
+      type: string
+      description: "Het type zakelijk recht dat deze gerechtigde heeft. Afgeleid van de aard zakelijk recht:\n
+      * `beklemrechthouder` - 1 Beklemrechthouder\n
+      * `eigenaar` - 2 Eigenaar\n
+      * `erfpachter` - 3 Erfpachter\n
+      * `gebruik_bewoning` - 4 Rechthebbende van Gebruik en bewoning\n
+      * `grondrente` - 5 Grondrente gerechtigde\n
+      * `opstalhouder` - 7 Opstalhouder\n
+      * `vaderlandsrecht` - 9 Rechthebbende van Oud-vaderlandsrecht\n
+      * `stadsmeierrecht` - 11 Rechthebbende van Stadsmeierrecht\n
+      * `vruchtgebruiker` - 12 Vruchtgebruiker\n
+      * `erfpachter_opstalhouder` - 13 Erfpachter en opstalhouder\n
+      * `nutsvoorzieningen` - 14 Opstalhouder nutsvoorzieningen\n
+      * `twee_belastingen` - 20 Zakelijk Rechthebbende na twee of meer zakelijke belastingen\n
+      * `belasting_derde` - 21 Zakelijk rechthebbende belasting derde of volgende\n
+      * `bp_recht` - 22 BP-gerechtigde\n
+      * `nutsvoorzieningen_gedeelte` - 23 Opstalhouder Nutsvoorzieningen op gedeelte van perceel\n
+      * `artikel5_3b` - 24 Zakelijk gerechtigde als bedoeld in artikel 5, lid 3, onder b, van de Belemmeringenwet Privaatrecht op gedeelte van perceel"
+      enum:
+        - "beklemrechthouder"
+        - "eigenaar"
+        - "erfpachter"
+        - "gebruik_bewoning"
+        - "grondrente"
+        - "opstalhouder"
+        - "vaderlandsrecht"
+        - "stadsmeierrecht"
+        - "vruchtgebruiker"
+        - "erfpachter_opstalhouder"
+        - "nutsvoorzieningen"
+        - "twee_belastingen"
+        - "belasting_derde"
+        - "bp_recht"
+        - "nutsvoorzieningen_gedeelte"
+        - "artikel5_3b"
     Geslacht_enum:
       type: "string"
       description: "Een aanduiding die aangeeft dat de ingeschrevene een man of een\
-        \ vrouw is, of dat het geslacht (nog) onbekend is:\n* `M` - Man\n* `V` - Vrouw\n\
-        * `O` - Onbekend"
+        \ vrouw is, of dat het geslacht (nog) onbekend is:\n* `man` - Man\n* `vrouw` - Vrouw\n\
+        * `onbekend` - Onbekend"
       enum:
       - "man"
       - "vrouw"
       - "onbekend"
-    TypePersoon_enum:
-      type: "string"
-      description: "Een ingeschrevenpersoon is een peroon die is geregistreerd in de BRP en dus een BSN heeft. Een kadasterpersoon is een persoon of een rechtspersoon die voorkomt in de registratie van het kadaster. :\n* `ingeschrevenpersoon`\n* `kadasterpersoon` "
-      enum:
-      - "ingeschrevenpersoon"
-      - "kadasterpersoon"
     Bedrag:
       type: "object"
       description: "Bedrag is samengesteld datatype voor het vastleggen van een hoeveelheid geld in cijfers in een bepaalde valuta."
@@ -1912,7 +1951,7 @@ components:
       type: "object"
       description: ""
       properties:
-        AKRregistercode: 
+        AKRregistercode:
           $ref: "#/components/schemas/Waardelijst"
         akrStukdeel1:
           type: "string"
@@ -1924,7 +1963,7 @@ components:
           type: "integer"
     TypeDeelEnNummer:
       type: "object"
-      properties: 
+      properties:
         soortregister:
           allOf:
           - $ref: "#/components/schemas/Waardelijst"
@@ -1939,7 +1978,7 @@ components:
           - description: "Mogelijke waarden zijn te vinden in deze [Waardelijst](http://www.kadaster.nl/schemas/waardelijsten/Reekscode/)"
     GeoJSONGeometry:
       title: GeoJSONGeometry
-      description: "Dit component is opgenomen om alle Geometry types ook bij het resolven op te lten nemen in de resolvde YAML. De resolver kan nog niet goed omgaan met de oneOf constructie en daardoor worden de componenten uit een oneOf in de common.yamlniet mee-geresolved. Deze constructie is inhoudelijk overbodig, maar wel nodig om dit probleem op te lossen" 
+      description: "Dit component is opgenomen om alle Geometry types ook bij het resolven op te lten nemen in de resolvde YAML. De resolver kan nog niet goed omgaan met de oneOf constructie en daardoor worden de componenten uit een oneOf in de common.yamlniet mee-geresolved. Deze constructie is inhoudelijk overbodig, maar wel nodig om dit probleem op te lossen"
       type: object
       oneOf:
       - $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/Point'
@@ -1949,4 +1988,3 @@ components:
       - $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/Polygon'
       - $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/MultiPolygon'
       - $ref: 'https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/master/api-specificatie/common.yaml#/components/schemas/GeometryCollection'
-      


### PR DESCRIPTION
- Parameter typegerechtigde op koz is string bij waardelijst, maar op zakger is enum
- TypeKadastraalOnroerendeZaak_enum description is leeg behalve het herhalen van de enumeratiewaarden (wat zinloos is)
- nummeraanduidingIdentificatie --> description "tamplated Halling naar de BAG"
- KadastraalOnroerendeZaak_links._links.zakelijkGerechtigden is array, maar kan maar één link zijn (zakelijk gerechtigde heeft geen identificatie en geen endpoint voor opvragen enkele resource).
- TypePersoon_enum gedefinieerd maar niet gebruikt
- KadasterNietNatuurlijkPersoon.metNaamOpenbaarRegister is array met property naam erin. Waarom niet gewoon array van string?
- Beslaglegger allOf volgorde onjuist voor code genereren (class waaruit overorven moet worden, moet als eerste genoemd worden.
- In description van endpoints opnemen welke attributen expand kunnen worden (toegepast in /kadastraalonroerendezaken en /kadastraalonroerendezaken/{kadastraalobjectidentificatie}): #303
- Aantekening verwijderen uit KadastraalOnroerendeZaak_embedded
- De zakelijkGerechtigden in KOZ._embedded is zonder HAL. Moet verwijzing naar ZakelijkGerechtigdeHal zijn opgenomen.


