### PR TITLE
description voor parametercombinaties

### DIFF
--- a/specificatie/BRK-Bevragen/openapi.yaml
+++ b/specificatie/BRK-Bevragen/openapi.yaml
@@ -18,17 +18,18 @@ paths:
       operationId: GetKadastraalOnroerendeZaken
       description: |
           Het ophalen van een collectie Kadastraal Onroerende zaken.
-          Ten minste één van de volgende combinaties van parameters moet zijn opgenomen
+          Ten minste één van de volgende combinaties van parameters moet moet worden gebruikt. Het combineren van parameters uit verschillende combinaties is niet toegestaan.
           1.  Kadastrale aanduiding
-              -  kadastrale_gemeente (verplicht)
+              -  kadastralegemeente__code (verplicht)
               -  perceelnummer (verplicht)
               -  sectie (verplicht)
               -  appartementsrechtnummer (optioneel)
           2.  Ingeschreven persoon als zakelijk gerechtigde
-              -  burgerservicenummer
+              -  burgerservicenummer (verplicht)
+              -  typegerechtigde (optioneel)
           3.  Niet ingeschreven persoon of niet natuurlijk persoon als zakelijk gerechtigde
-              -  kadastraalpersoonidentificatie
-              -  typegerechtigde
+              -  kadasterpersoonidentificatie (verplicht)
+              -  typegerechtigde (optioneel)
           4.  Adres
               -  postcode (verplicht)
               -  huisnummer (optioneel)

--- a/specificatie/BRK-Bevragen/openapi.yaml
+++ b/specificatie/BRK-Bevragen/openapi.yaml
@@ -18,7 +18,7 @@ paths:
       operationId: GetKadastraalOnroerendeZaken
       description: |
           Het ophalen van een collectie Kadastraal Onroerende zaken.
-          Ten minste één van de volgende combinaties van parameters moet moet worden gebruikt. Het combineren van parameters uit verschillende combinaties is niet toegestaan.
+          Ten minste één van de volgende combinaties van parameters moet worden gebruikt. Het combineren van parameters uit verschillende combinaties is niet toegestaan.
           1.  Kadastrale aanduiding
               -  kadastralegemeente__code (verplicht)
               -  perceelnummer (verplicht)


### PR DESCRIPTION
de beschrijving bij endpoint /kadastraalonroerendezaken wijzigen, zodat het in lijn is met de implementatie.
De gebruiker moet kiezen welk zoekpad gebruikt wordt, bestaande uit een beperkte combinatie van parameters (waarvan bij dat zoekpad sommige parameters verplicht zijn en andere optioneel). Het combineren van parameters uit meerdere zoekpaden/parametercombinaties is niet toegestaan en zal een 400 bad request leveren.