### PR TITLE
Aanpassingen in de openapi specs

### DIFF
--- a/specificatie/BRK-Bevragen/genereervariant/openapi.yaml
+++ b/specificatie/BRK-Bevragen/genereervariant/openapi.yaml
@@ -174,7 +174,8 @@ paths:
         style: form
         explode: true
         schema:
-          pattern: ^[1-9][0-9]{0,4}$
+          minimum: 1
+          maximum: 99999
           type: integer
       - name: adres__huisletter
         in: query
@@ -672,7 +673,7 @@ paths:
                   to a temporary overloading or maintenance of the server.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAvailable
-  /kadastraalonroerendezaken/{kadastraalonroerendezaakidentificatie}/zakelijkgerechtigden/{zakelijkgerechtigdeidentificatie]:
+  /kadastraalonroerendezaken/{kadastraalonroerendezaakidentificatie}/zakelijkgerechtigden/{zakelijkgerechtigdeidentificatie}:
     get:
       tags:
       - Zakelijke Gerechtigden
@@ -3828,7 +3829,7 @@ components:
         einddatum:
           type: string
           format: date
-        eindatumRecht:
+        einddatumRecht:
           type: string
           format: date
         indicatieOorspronkelijkObject:

--- a/specificatie/BRK-Bevragen/genereervariant/openapi.yaml
+++ b/specificatie/BRK-Bevragen/genereervariant/openapi.yaml
@@ -3834,8 +3834,6 @@ components:
           format: date
         indicatieOorspronkelijkObject:
           type: boolean
-        naamKavelruil:
-          type: string
         betreftGedeelteVanPerceel:
           type: boolean
         stukIdentificaties:
@@ -3860,10 +3858,10 @@ components:
       description: Hieraan wordt een Kadasterstuk of een Aangebodenstuk gekoppeld.
         Een stuk is een brondocument dat aanleiding geeft tot een wijziging van de
         gegevens in een basisregistratie.
-    AmbtelijkCorrectiegegevenID:
+    PortefeuilleId:
       type: object
       properties:
-        AKRregistercode:
+        akrRegistercode:
           $ref: '#/components/schemas/Waardelijst'
         akrStukdeel1:
           type: string
@@ -4183,11 +4181,8 @@ components:
       allOf:
       - $ref: '#/components/schemas/AbstractStuk'
       - properties:
-          indicatieCorrectie:
-            title: indicatieCorrectie
-            type: boolean
-          acgIdentificatie:
-            $ref: '#/components/schemas/AmbtelijkCorrectiegegevenID'
+          portefeuilleNummer:
+            $ref: '#/components/schemas/PortefeuilleId'
         description: Een Kadasterstuk is een document dat alleen door het Kadaster
           gebruikt wordt. Met dit document worden veranderingen aangebracht in de
           Basisregistratie Kadaster, maar het is niet terug te vinden in de openbare


### PR DESCRIPTION
- aanpassingen nav vraag van klant welke imkad versie we gebruikten. Heb de mapping gecheckt en zag dat er nog een paar elementen in staan uit imkad 2.2. Zie https://developer.kadaster.nl/schemas/imkad/20200130/wijzigingen.html
- pattern aanpassing bij validatie huisnummer
- typos