### PR TITLE
Bij ZakelijkGerechtigde _embedded toegevoegd en ook hypotheken en besl…

### DIFF
--- a/specificatie/BRK-Bevragen/openapi.yaml
+++ b/specificatie/BRK-Bevragen/openapi.yaml
@@ -2109,6 +2109,14 @@ components:
           items:
             type: "string"
             description: "De identificaties van het stukdelen waarin deze tenaamstelling is vermeld"
+        hypotheekIdentificaties:
+          type: "array"
+          items:
+            type: "string"
+        beslagIdentificaties:
+          type: "array"
+          items:
+            type: "string"
     TypeBreuk:
       type: "object"
       description: "Een deling van twee gehele getallen"
@@ -2310,6 +2318,8 @@ components:
       - properties:
           _links:
             $ref: "#/components/schemas/ZakelijkGerechtigde_links"
+          _embedded:
+            $ref: "#/components/schemas/ZakelijkGerechtigde_embedded"
     ZakelijkGerechtigdeHalCollectie:
       type: "object"
       properties:
@@ -2335,7 +2345,6 @@ components:
           type: "array"
           items:
             $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/schemas/HalLink"
-
         persoon:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         betrokkenPartner:
@@ -2344,3 +2353,31 @@ components:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         betrokkenGorzenEnAanwassen:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+        hypotheken:
+          type: "array"
+          items:
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+        beslagen:
+          type: "array"
+          items:
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+    ZakelijkGerechtigde_embedded:
+      type: "object"
+      properties:
+        stukken:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/AangebodenStuk"
+        stukdelen:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/Stukdeel"
+        hypotheken:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/Hypotheek"
+        beslagen:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/Beslag"
+# Hier eventueel nog de HalBasis introduceren om in de embedded resources op het laagste niveau wel de links mee te krijgen. Weet niet of dat Breaking is.......


### PR DESCRIPTION
…agen daarin opgenomen (ook in de _links en de identificaties in de tenaamstelling). Nu kan in 1 resource de volledige gegevensset van een kadastraalonroerende zaak meegegeven worden. 