### PR TITLE
Domein toevoegen aan resource identificaties

### DIFF
--- a/specificatie/BRK-Bevragen/genereervariant/openapi.yaml
+++ b/specificatie/BRK-Bevragen/genereervariant/openapi.yaml
@@ -2179,6 +2179,9 @@ components:
       properties:
         identificatie:
           type: string
+        domein:
+          type: "string"
+          description: "Het domein waartoe de identificatie behoort."
         aard:
           $ref: '#/components/schemas/Waardelijst'
         omschrijving:

--- a/specificatie/BRK-Bevragen/genereervariant/openapi.yaml
+++ b/specificatie/BRK-Bevragen/genereervariant/openapi.yaml
@@ -2340,6 +2340,9 @@ components:
       allOf:
       - $ref: '#/components/schemas/PersoonBasis'
       - properties:
+          domein:
+            type: string
+            description: Het domein waartoe de identificatie behoort.
           indicatieNietToonbareDiakriet:
             type: boolean
           beschikkingsbevoegdheid:
@@ -2382,6 +2385,9 @@ components:
       properties:
         identificatie:
           type: string
+        domein:
+          type: string
+          description: Het domein waartoe de identificatie behoort.
         begrenzingPerceel:
           $ref: '#/components/schemas/polygonGeoJSON'
         perceelnummerRotatie:

--- a/specificatie/BRK-Bevragen/openapi.yaml
+++ b/specificatie/BRK-Bevragen/openapi.yaml
@@ -737,6 +737,9 @@ components:
             Waardelijst in deze component :
             [beschikkingsbevoegdheid](http://www.kadaster.nl/schemas/waardelijsten/Beschikkingsbevoegdheid/)"
           properties:
+            domein:
+              type: "string"
+              description: "Het domein waartoe de identificatie behoort."
             indicatieNietToonbareDiakriet:
               type: "boolean"
             beschikkingsbevoegdheid:
@@ -781,6 +784,9 @@ components:
       properties:
         identificatie:
           type: "string"
+        domein:
+          type: "string"
+          description: "Het domein waartoe de identificatie behoort."
         begrenzingPerceel:
           $ref: "http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/polygonGeoJSON.yaml"
         perceelnummerRotatie:

--- a/specificatie/BRK-Bevragen/openapi.yaml
+++ b/specificatie/BRK-Bevragen/openapi.yaml
@@ -554,6 +554,9 @@ components:
       properties:
         identificatie:
           type: "string"
+        domein:
+          type: "string"
+          description: "Het domein waartoe de identificatie behoort."
         aard:
           $ref: "#/components/schemas/Waardelijst"
           description: "Mogelijke waarden zijn te vinden in deze [Waardelijst](http://www.kadaster.nl/schemas/waardelijsten/AardAantekening/)"


### PR DESCRIPTION
Naast identificatie is ook property "domein" opgenomen bij resources kadastraalonroerendezaken, kadasternatuurlijkpersonen en kadasternietnatuurlijkpersonen.

Zie #510 