### PR TITLE
Security (obv apiKey) toegevoegd aan openapi specificatie

### DIFF
--- a/specificatie/BRK-Bevragen/openapi.yaml
+++ b/specificatie/BRK-Bevragen/openapi.yaml
@@ -12,6 +12,8 @@ info:
   license:
     name: European Union Public License, version 1.2 (EUPL-1.2)
     url: https://eupl.eu/1.2/nl/
+security:
+  - apiKeyAuth: []
 paths:
   /kadastraalonroerendezaken:
     get:
@@ -494,6 +496,12 @@ paths:
       tags:
       - Kadaster (niet)Natuurlijk Personen
 components:
+  securitySchemes:
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-Api-Key
+      description: "De API-key dient bij elk request via de `X-Api-Key` request header meegestuurd te worden."
   schemas:
     Aantekening:
       type: "object"


### PR DESCRIPTION
**Informatie:**
https://swagger.io/docs/specification/authentication/api-keys/

Verder heb ik de naam van de header gelijk getrokken met die van de BAG API.
