### PR TITLE
volgorde servers gewijzigd t.b.v. postman collection

### DIFF
--- a/specificatie/BRK-Bevragen/genereervariant/openapi.json
+++ b/specificatie/BRK-Bevragen/genereervariant/openapi.json
@@ -14,14 +14,14 @@
     "version" : "1.1.0"
   },
   "servers" : [ {
-    "url" : "https://api.brk.kadaster.nl/esd/bevragen/v1",
-    "description" : "BRK-Bevragen API - PRODUCTIE"
+    "url" : "https://api.brk.kadaster.nl/esd-eto-apikey/bevragen/v1",
+    "description" : "BRK-Bevragen API - TEST (via API-key)"
   }, {
     "url" : "https://api.brk.kadaster.nl/esd-eto/bevragen/v1",
     "description" : "BRK-Bevragen API - TEST (via API-key & mTLS)"
   }, {
-    "url" : "https://api.brk.kadaster.nl/esd-eto-apikey/bevragen/v1",
-    "description" : "BRK-Bevragen API - TEST (via API-key)"
+    "url" : "https://api.brk.kadaster.nl/esd/bevragen/v1",
+    "description" : "BRK-Bevragen API - PRODUCTIE"
   } ],
   "security" : [ {
     "apiKeyAuth" : [ ]
@@ -40,8 +40,8 @@
           "schema" : {
             "type" : "string",
             "description" : "CRS van de coördinaten in de response. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel.",
-            "enum" : [ "epsg:28992" ],
-            "default" : "epsg:28992"
+            "default" : "epsg:28992",
+            "enum" : [ "epsg:28992" ]
           }
         }, {
           "name" : "expand",
@@ -363,8 +363,8 @@
           "schema" : {
             "type" : "string",
             "description" : "CRS van de coördinaten in de response. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel.",
-            "enum" : [ "epsg:28992" ],
-            "default" : "epsg:28992"
+            "default" : "epsg:28992",
+            "enum" : [ "epsg:28992" ]
           }
         }, {
           "name" : "expand",
@@ -2988,8 +2988,8 @@
         "description" : "CRS van de meegegeven geometrie. epsg:28992 mapt op het RD New Nederlands coordinatenstelsel.",
         "schema" : {
           "type" : "string",
-          "enum" : [ "epsg:28992" ],
-          "default" : "epsg:28992"
+          "default" : "epsg:28992",
+          "enum" : [ "epsg:28992" ]
         }
       },
       "warning" : {

--- a/specificatie/BRK-Bevragen/genereervariant/openapi.yaml
+++ b/specificatie/BRK-Bevragen/genereervariant/openapi.yaml
@@ -12,12 +12,12 @@ info:
     url: https://eupl.eu/1.2/nl/
   version: 1.1.0
 servers:
-- url: https://api.brk.kadaster.nl/esd/bevragen/v1
-  description: BRK-Bevragen API - PRODUCTIE
-- url: https://api.brk.kadaster.nl/esd-eto/bevragen/v1
-  description: BRK-Bevragen API - TEST (via API-key & mTLS)
 - url: https://api.brk.kadaster.nl/esd-eto-apikey/bevragen/v1
   description: BRK-Bevragen API - TEST (via API-key)
+- url: https://api.brk.kadaster.nl/esd-eto/bevragen/v1
+  description: BRK-Bevragen API - TEST (via API-key & mTLS)
+- url: https://api.brk.kadaster.nl/esd/bevragen/v1
+  description: BRK-Bevragen API - PRODUCTIE
 security:
 - apiKeyAuth: []
 paths:
@@ -53,9 +53,9 @@ paths:
           type: string
           description: CRS van de coördinaten in de response. epsg:28992 mapt op het
             RD New Nederlands coordinatenstelsel.
-          default: epsg:28992
           enum:
           - epsg:28992
+          default: epsg:28992
       - name: expand
         in: query
         description: Hiermee kun je opgeven welke gerelateerde resources meegeleverd
@@ -346,9 +346,9 @@ paths:
           type: string
           description: CRS van de coördinaten in de response. epsg:28992 mapt op het
             RD New Nederlands coordinatenstelsel.
-          default: epsg:28992
           enum:
           - epsg:28992
+          default: epsg:28992
       - name: expand
         in: query
         description: Hiermee kun je opgeven welke gerelateerde resources meegeleverd
@@ -2490,9 +2490,9 @@ components:
         Nederlands coordinatenstelsel.
       schema:
         type: string
-        default: epsg:28992
         enum:
         - epsg:28992
+        default: epsg:28992
     warning:
       schema:
         type: string

--- a/specificatie/BRK-Bevragen/openapi.yaml
+++ b/specificatie/BRK-Bevragen/openapi.yaml
@@ -1,11 +1,11 @@
 openapi: 3.0.0
 servers:
-  - description: "BRK-Bevragen API - PRODUCTIE"
-    url: https://api.brk.kadaster.nl/esd/bevragen/v1
-  - description: "BRK-Bevragen API - TEST (via API-key & mTLS)"
-    url: https://api.brk.kadaster.nl/esd-eto/bevragen/v1
   - description: "BRK-Bevragen API - TEST (via API-key)"
     url: https://api.brk.kadaster.nl/esd-eto-apikey/bevragen/v1
+  - description: "BRK-Bevragen API - TEST (via API-key & mTLS)"
+    url: https://api.brk.kadaster.nl/esd-eto/bevragen/v1
+  - description: "BRK-Bevragen API - PRODUCTIE"
+    url: https://api.brk.kadaster.nl/esd/bevragen/v1
 info:
   title: Kadaster - BRK-Bevragen API
   description: "D.m.v. deze toepassing worden meerdere, korte bevragingen op de Basis Registratie Kadaster beschikbaar gesteld. Deze toepassing betreft het verstrekken van Kadastrale Onroerende Zaak informatie."

--- a/test/BRK-Bevragen-postman-collection.json
+++ b/test/BRK-Bevragen-postman-collection.json
@@ -1,11 +1,11 @@
 {
     "item": [
         {
-            "id": "665e0265-7542-4d95-8ee0-b6f1dbe0058f",
+            "id": "a37b4d31-8802-41f6-bdfc-5c441acf0a52",
             "name": "kadastraalonroerendezaken",
             "item": [
                 {
-                    "id": "42dba89c-e9fe-4500-9f24-5c2746d67476",
+                    "id": "98793123-c3b3-4ba0-b55b-92aa0bae4695",
                     "name": "Get Kadastraal Onroerende Zaken",
                     "request": {
                         "name": "Get Kadastraal Onroerende Zaken",
@@ -86,7 +86,7 @@
                     },
                     "response": [
                         {
-                            "id": "e03a1b08-2b69-4cfc-86ad-1b95351c808b",
+                            "id": "deeaa17a-01fa-45aa-b219-851231dfbe79",
                             "name": "Zoekactie geslaagd",
                             "originalRequest": {
                                 "url": {
@@ -178,7 +178,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9da17e23-019c-44b7-b579-a6f3baf7d141",
+                            "id": "6ab800ee-6037-4d92-b0b2-f36db1760789",
                             "name": "Bad Request",
                             "originalRequest": {
                                 "url": {
@@ -260,7 +260,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "47abe411-811c-41aa-bea3-92f7fa28178c",
+                            "id": "ad64748b-5c94-4dfb-b766-f27ceeec6dc5",
                             "name": "Unauthorized",
                             "originalRequest": {
                                 "url": {
@@ -342,7 +342,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "20e1b212-337e-4e13-a3c4-cce283b6669c",
+                            "id": "dd6860e3-977d-43b9-8dfb-08f53078f846",
                             "name": "Forbidden",
                             "originalRequest": {
                                 "url": {
@@ -424,7 +424,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "85cb1fa5-1534-4ad5-bf1d-111f789b1f45",
+                            "id": "8ca9cb67-59d4-4cb0-80a1-08d37090c03f",
                             "name": "Not Acceptable",
                             "originalRequest": {
                                 "url": {
@@ -506,7 +506,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "56912ce2-1de6-4969-8152-bdffaacf442a",
+                            "id": "b645fdd4-1995-45e1-b80c-cba363f17139",
                             "name": "Gone",
                             "originalRequest": {
                                 "url": {
@@ -588,7 +588,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "30909cb0-2f9e-4b00-948a-632db2451eb5",
+                            "id": "5761e275-c9ca-44ad-b72f-476a38ba703d",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -670,7 +670,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "156f688f-2530-4e1b-a685-ca5e84304d79",
+                            "id": "d96d79a2-4a97-420a-99c8-1879d7801b0e",
                             "name": "Service Unavailable",
                             "originalRequest": {
                                 "url": {
@@ -755,11 +755,11 @@
                     "event": []
                 },
                 {
-                    "id": "5abc097b-5ea1-4ca3-977c-c1d797aacd95",
+                    "id": "2a1933f5-ddb3-4ed9-b402-7b25f1460da2",
                     "name": "{kadastraalonroerendezaakidentificatie}",
                     "item": [
                         {
-                            "id": "07820417-412f-4f85-b9f0-8e947649d18f",
+                            "id": "4714bb4a-8d8e-42ef-bbd6-a734570fd609",
                             "name": "Get Kadastraal Onroerende Zaak",
                             "request": {
                                 "name": "Get Kadastraal Onroerende Zaak",
@@ -808,7 +808,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "aad9b073-1c6e-475d-9268-2414fe318dac",
+                                    "id": "a9cf156f-ec99-4967-ae1a-76ec439933ff",
                                     "name": "Zoekactie geslaagd",
                                     "originalRequest": {
                                         "url": {
@@ -874,7 +874,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "12adcf52-84a6-4118-8765-0103ae377bbf",
+                                    "id": "93f42218-1be2-4c8c-a73a-0816fcc5b6bd",
                                     "name": "Bad Request",
                                     "originalRequest": {
                                         "url": {
@@ -930,7 +930,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "3ebfd14b-e6ba-409f-85c7-39334e0f5273",
+                                    "id": "c3801872-2c53-4737-879d-b9e0e9b3c37b",
                                     "name": "Unauthorized",
                                     "originalRequest": {
                                         "url": {
@@ -986,7 +986,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "41f2b749-3b43-44f9-854b-b831e9d29423",
+                                    "id": "7a1d9eeb-c6a9-4305-8db4-dd4fd64bcdc4",
                                     "name": "Forbidden",
                                     "originalRequest": {
                                         "url": {
@@ -1042,7 +1042,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "38f971c0-1711-481c-841c-e4a533b2a62d",
+                                    "id": "05f410d6-592d-49a7-8f17-da33c73bacc9",
                                     "name": "Not Found",
                                     "originalRequest": {
                                         "url": {
@@ -1098,7 +1098,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "b6680756-0777-47ff-8e70-65d7db6da284",
+                                    "id": "1c7e03d5-1b93-4827-b334-c1586d301630",
                                     "name": "Not Acceptable",
                                     "originalRequest": {
                                         "url": {
@@ -1154,7 +1154,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "ce76cc21-23b6-4f1e-9357-b1b5fc873e03",
+                                    "id": "e5551e50-e7b7-41ec-9402-34de852cb5f0",
                                     "name": "Gone",
                                     "originalRequest": {
                                         "url": {
@@ -1210,7 +1210,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "2efe43a5-1a8b-48f1-a7e4-a89bdba22b42",
+                                    "id": "e8c3b08f-d341-4b98-aac2-361b8d999f65",
                                     "name": "Internal Server Error",
                                     "originalRequest": {
                                         "url": {
@@ -1266,7 +1266,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "7c2f2955-cdc4-4412-b098-d40fef8a61ac",
+                                    "id": "bbb76167-fdcc-4c5d-8827-1a7350859e75",
                                     "name": "Service Unavailable",
                                     "originalRequest": {
                                         "url": {
@@ -1325,11 +1325,11 @@
                             "event": []
                         },
                         {
-                            "id": "13ff416f-84fb-491d-ad6b-881e3bc93b98",
+                            "id": "31ff72ca-0127-4b83-90bf-9da646aa042e",
                             "name": "zakelijkgerechtigden",
                             "item": [
                                 {
-                                    "id": "166142ad-8bd2-4d2e-be96-6bce0f812831",
+                                    "id": "2923bcef-e95d-4cc9-89bf-4813ebda107b",
                                     "name": "Get Zakelijk Gerechtigden",
                                     "request": {
                                         "name": "Get Zakelijk Gerechtigden",
@@ -1372,7 +1372,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "44815695-b5bb-4e45-a106-e1e433e916dd",
+                                            "id": "f037f4a1-7745-4122-8d0e-25db113e2e7f",
                                             "name": "Zoekactie geslaagd",
                                             "originalRequest": {
                                                 "url": {
@@ -1427,7 +1427,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "5fe20889-9f81-418c-b589-f31c3fa6633e",
+                                            "id": "f40f2026-4e7d-45d9-bbbc-c8ffd02fc57f",
                                             "name": "Bad Request",
                                             "originalRequest": {
                                                 "url": {
@@ -1477,7 +1477,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "12e21a48-e238-49c1-a2d9-3bc60f578047",
+                                            "id": "b5c6bc9b-28e1-4e6e-aba5-a7bd61eee848",
                                             "name": "Unauthorized",
                                             "originalRequest": {
                                                 "url": {
@@ -1527,7 +1527,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "f813eeb4-7d4d-4ac8-b4d0-c3ea103abf3c",
+                                            "id": "33370dee-b5f3-48a6-aff3-b6352636063b",
                                             "name": "Forbidden",
                                             "originalRequest": {
                                                 "url": {
@@ -1577,7 +1577,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "3a5497bd-5d8b-4649-8001-b648ecd4682d",
+                                            "id": "949691d4-053e-47d7-9ce4-c01b46416320",
                                             "name": "Not Found",
                                             "originalRequest": {
                                                 "url": {
@@ -1627,7 +1627,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "75a6ed3d-4721-4019-a84f-80377f1b9d97",
+                                            "id": "01fc2f91-7137-4f6b-8aad-9e7a5b34785a",
                                             "name": "Not Acceptable",
                                             "originalRequest": {
                                                 "url": {
@@ -1677,7 +1677,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "43b7ecf9-9755-4903-beca-420c7f24da0e",
+                                            "id": "7bd7fc8c-61e4-4778-8c2f-7400ccf77d05",
                                             "name": "Gone",
                                             "originalRequest": {
                                                 "url": {
@@ -1727,7 +1727,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "d2ada6b1-9dac-47ac-a181-2a4e84ec99ea",
+                                            "id": "a8feb06b-5089-416e-b1d1-4771d0180a93",
                                             "name": "Internal Server Error",
                                             "originalRequest": {
                                                 "url": {
@@ -1777,7 +1777,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "627720e7-3149-4733-8a56-c69f221f1c6c",
+                                            "id": "728fb4e7-0694-4dd9-ab30-0ee28f692c67",
                                             "name": "Service Unavailable",
                                             "originalRequest": {
                                                 "url": {
@@ -1830,7 +1830,7 @@
                                     "event": []
                                 },
                                 {
-                                    "id": "dd4b96e6-06c2-4b56-a56a-89c6f9433d1b",
+                                    "id": "e353a5a1-a760-4b60-a2e9-cfe08abf0d13",
                                     "name": "Get Zakelijk Gerechtigde",
                                     "request": {
                                         "name": "Get Zakelijk Gerechtigde",
@@ -1875,7 +1875,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "2d8d79b6-18ac-4edb-aba5-94eb84d6ac4c",
+                                            "id": "cee1558e-a799-49cb-9624-b656088b87bd",
                                             "name": "Zoekactie geslaagd",
                                             "originalRequest": {
                                                 "url": {
@@ -1931,7 +1931,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "02e29da0-2e74-464d-baf5-3f11f4d4da49",
+                                            "id": "d0781664-f7e6-4e5d-9357-8540fc8c02cc",
                                             "name": "Bad Request",
                                             "originalRequest": {
                                                 "url": {
@@ -1982,7 +1982,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "95cc3c72-e3d8-423f-b2c5-281d4af66a7d",
+                                            "id": "7b3e5808-97f4-4257-b947-9e084279b138",
                                             "name": "Unauthorized",
                                             "originalRequest": {
                                                 "url": {
@@ -2033,7 +2033,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "bea986bb-e217-44bc-be22-f95e9e1af1c0",
+                                            "id": "cf9388f7-df25-4b23-8301-9e5c3417b64d",
                                             "name": "Forbidden",
                                             "originalRequest": {
                                                 "url": {
@@ -2084,7 +2084,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "b6fe980b-b742-4383-8ee8-dcae21a7bc16",
+                                            "id": "c66237db-4cfe-493d-b82a-b6e2c00c56e2",
                                             "name": "Not Found",
                                             "originalRequest": {
                                                 "url": {
@@ -2135,7 +2135,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "d31d1822-80a5-49c1-97cf-4ca9588b9d74",
+                                            "id": "18d9732e-08be-477c-98bd-e3492b05606f",
                                             "name": "Not Acceptable",
                                             "originalRequest": {
                                                 "url": {
@@ -2186,7 +2186,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "a94ba736-158e-4d99-b51d-3b0fb21809e3",
+                                            "id": "8e63d74f-8f15-4a0c-9537-1424ddd1b017",
                                             "name": "Gone",
                                             "originalRequest": {
                                                 "url": {
@@ -2237,7 +2237,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "d2be7abf-c674-4623-8c56-23b331ced922",
+                                            "id": "7340cf68-b1f7-4043-81f4-1899324454a9",
                                             "name": "Internal Server Error",
                                             "originalRequest": {
                                                 "url": {
@@ -2288,7 +2288,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "5c3fea35-2686-4617-99e9-eb835c9cc7f1",
+                                            "id": "2b804e2a-71bb-4a42-9696-ae8a4a9bedad",
                                             "name": "Service Unavailable",
                                             "originalRequest": {
                                                 "url": {
@@ -2351,11 +2351,11 @@
             "event": []
         },
         {
-            "id": "07199c7d-727e-4596-a520-6b3ee9e73c5a",
+            "id": "28e9a3c7-2f2c-4e7a-8087-8ee296bfd641",
             "name": "kadasternatuurlijkpersonen",
             "item": [
                 {
-                    "id": "da1a2413-8fb8-4331-8838-09b46e3369c1",
+                    "id": "9681c2f9-dc4b-404e-8c8e-ff33a5b3dc11",
                     "name": "Get Kadaster Personen",
                     "request": {
                         "name": "Get Kadaster Personen",
@@ -2389,7 +2389,7 @@
                     },
                     "response": [
                         {
-                            "id": "d3c5a47a-e20b-40df-a430-2ac31fecbd7d",
+                            "id": "6aeb31d4-6902-4786-a76a-fd22cddbcb10",
                             "name": "Zoekactie geslaagd",
                             "originalRequest": {
                                 "url": {
@@ -2437,7 +2437,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c2d298f2-4160-43c6-9f8e-1ea81fc1e775",
+                            "id": "0a3d4c83-bd3d-4ffe-8259-e0b1a5c18860",
                             "name": "Bad Request",
                             "originalRequest": {
                                 "url": {
@@ -2480,7 +2480,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "332431e5-ea9e-45c6-aa66-85ed6dcdaac8",
+                            "id": "10334fac-945b-4cdf-b86d-3ae3cca07afb",
                             "name": "Unauthorized",
                             "originalRequest": {
                                 "url": {
@@ -2523,7 +2523,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5636f8f1-c323-4ebd-a280-d2c591713beb",
+                            "id": "16fc9ebc-7e4f-441c-88d6-97df0d1cb27f",
                             "name": "Forbidden",
                             "originalRequest": {
                                 "url": {
@@ -2566,7 +2566,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "365aaf38-e9c2-4b98-80a5-235cc830ac7b",
+                            "id": "48014ac5-6f90-4b4a-a211-b619134823c0",
                             "name": "Not Acceptable",
                             "originalRequest": {
                                 "url": {
@@ -2609,7 +2609,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1e716c1a-2e10-4e30-bb77-44091617d613",
+                            "id": "13b5d64f-ab39-40ed-a489-fa2e9742fc08",
                             "name": "Gone",
                             "originalRequest": {
                                 "url": {
@@ -2652,7 +2652,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2382188a-fe16-4f1c-8e0d-c654631dd31e",
+                            "id": "8a758330-5cf0-4311-a247-5c05ec2d0b43",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -2695,7 +2695,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "309b4de4-a3c9-4d28-88a9-c8a5ab677a33",
+                            "id": "eb3dc360-0e89-4f9e-a35b-ad06dfe2bff4",
                             "name": "Service Unavailable",
                             "originalRequest": {
                                 "url": {
@@ -2741,7 +2741,7 @@
                     "event": []
                 },
                 {
-                    "id": "999d6a9b-0460-4882-8e07-a0a2163e207c",
+                    "id": "a072995c-66f2-47c3-8bad-6bc8ad73c20f",
                     "name": "Get Kadaster Persoon",
                     "request": {
                         "name": "Get Kadaster Persoon",
@@ -2778,7 +2778,7 @@
                     },
                     "response": [
                         {
-                            "id": "b9c4192e-e181-4652-8b8b-0596566860bb",
+                            "id": "be3faa4a-7fb0-4b77-934f-3141fe162c05",
                             "name": "Zoekactie geslaagd",
                             "originalRequest": {
                                 "url": {
@@ -2828,7 +2828,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "28521523-1f23-4d59-9450-df3f92c15edd",
+                            "id": "dabd67d7-dca8-4abb-b537-240a89065f51",
                             "name": "Bad Request",
                             "originalRequest": {
                                 "url": {
@@ -2873,7 +2873,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "43bf9661-4fd8-418b-bf52-239141ab016c",
+                            "id": "35e3e71d-8575-48d5-add1-81064206c6e0",
                             "name": "Unauthorized",
                             "originalRequest": {
                                 "url": {
@@ -2918,7 +2918,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b7676690-db04-44a3-8068-ed686554c26b",
+                            "id": "ee18ec3a-7e11-4924-9fd3-6295c5c888e0",
                             "name": "Forbidden",
                             "originalRequest": {
                                 "url": {
@@ -2963,7 +2963,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "16a47da7-2499-4c72-98cb-c2a25a1add1d",
+                            "id": "002464f0-2b4e-4aee-8c5a-ed750a6312c1",
                             "name": "Not Found",
                             "originalRequest": {
                                 "url": {
@@ -3008,7 +3008,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "93295244-652a-489a-8e98-f05bb8d1f1ec",
+                            "id": "700097be-2b5f-4f4a-8e90-c0346a8e197e",
                             "name": "Not Acceptable",
                             "originalRequest": {
                                 "url": {
@@ -3053,7 +3053,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "62266c9c-29f6-471f-8892-a4a4feaccb0d",
+                            "id": "e25e3def-51c9-4369-bcaa-9b425c0e6314",
                             "name": "Gone",
                             "originalRequest": {
                                 "url": {
@@ -3098,7 +3098,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2e7c3604-9eac-4f69-9d9c-e123b7f13e4d",
+                            "id": "d4a1e624-c340-4a8d-b155-23718428ac95",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -3143,7 +3143,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c8b90adf-bc5c-4f50-8825-020cbe21b40d",
+                            "id": "bf0bc0bb-56ac-4123-9c36-ed13e2792485",
                             "name": "Service Unavailable",
                             "originalRequest": {
                                 "url": {
@@ -3194,11 +3194,11 @@
             "event": []
         },
         {
-            "id": "9277a15c-6b52-4578-a955-7be29503ba9a",
+            "id": "35df7ad4-658a-442e-83b4-3266d09d83b0",
             "name": "kadasternietnatuurlijkpersonen",
             "item": [
                 {
-                    "id": "7fe71789-75ea-47be-88e3-ad21d9073b24",
+                    "id": "7b12a338-ee38-402f-97c0-ade7c35a10c5",
                     "name": "Get Kadaster Niet Natuurlijk Personen",
                     "request": {
                         "name": "Get Kadaster Niet Natuurlijk Personen",
@@ -3232,7 +3232,7 @@
                     },
                     "response": [
                         {
-                            "id": "16e077cb-d4de-4f91-8dff-b6f3ce397950",
+                            "id": "781dc4d8-c1c4-42bb-a6ef-b86ca7d9cdc4",
                             "name": "Zoekactie geslaagd",
                             "originalRequest": {
                                 "url": {
@@ -3280,7 +3280,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "782c4b77-22c9-4590-a088-d8c56c9f6859",
+                            "id": "5a37f035-e98c-41fb-9ebd-629a6472c6b7",
                             "name": "Bad Request",
                             "originalRequest": {
                                 "url": {
@@ -3323,7 +3323,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e55bf3e5-902f-4baf-bced-9efd410011ad",
+                            "id": "db9e4126-f6e1-4a73-9b91-4c9755415732",
                             "name": "Unauthorized",
                             "originalRequest": {
                                 "url": {
@@ -3366,7 +3366,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "f44ab7cc-c6ac-433c-bb31-76037427e389",
+                            "id": "9947ba02-43d2-49f8-b69f-aa79e286075e",
                             "name": "Forbidden",
                             "originalRequest": {
                                 "url": {
@@ -3409,7 +3409,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "011ef97d-8da0-405b-bbe0-3609d95786c3",
+                            "id": "4605635b-1bec-45a3-bd7f-1439a0e0ba04",
                             "name": "Not Acceptable",
                             "originalRequest": {
                                 "url": {
@@ -3452,7 +3452,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e083b7c1-47bd-4030-bd6e-b7c10a4fc0b4",
+                            "id": "f7c2d11d-b7fd-4757-a9b2-b60dc589d2f2",
                             "name": "Gone",
                             "originalRequest": {
                                 "url": {
@@ -3495,7 +3495,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "7786d4e6-f864-4570-94b8-b5b5ae00e98a",
+                            "id": "3bc635b9-05ca-4532-9baa-b92f167bb2a5",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -3538,7 +3538,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "8e133bf7-9462-4467-aa09-d4d7870c6cdb",
+                            "id": "ea97322d-7f41-4d0d-9baa-5601b38cb29f",
                             "name": "Service Unavailable",
                             "originalRequest": {
                                 "url": {
@@ -3584,7 +3584,7 @@
                     "event": []
                 },
                 {
-                    "id": "172d22c7-7bf2-4f89-8a15-6a491680b4ac",
+                    "id": "e6623595-5ae1-415b-9a34-c1b4820bb8cd",
                     "name": "Get Kadaster Niet Natuurlijk Persoon",
                     "request": {
                         "name": "Get Kadaster Niet Natuurlijk Persoon",
@@ -3621,7 +3621,7 @@
                     },
                     "response": [
                         {
-                            "id": "9d64d194-f404-4708-8984-0ba7faa4fbbb",
+                            "id": "cef86168-7cce-4e4e-930a-4c3bf4af39ae",
                             "name": "Zoekactie geslaagd",
                             "originalRequest": {
                                 "url": {
@@ -3671,7 +3671,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "16e0308b-07e6-43cf-aa95-ca2b11f8e31a",
+                            "id": "389b2672-d59f-4d65-abb7-9b17810dccc6",
                             "name": "Bad Request",
                             "originalRequest": {
                                 "url": {
@@ -3716,7 +3716,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3d700c3a-bfb7-4c57-82c8-eca49b2cf5e3",
+                            "id": "2540090f-668f-4ff1-b5a2-06448b5d136d",
                             "name": "Unauthorized",
                             "originalRequest": {
                                 "url": {
@@ -3761,7 +3761,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "86c0879e-c19b-49b0-853a-0d788020e048",
+                            "id": "4d04684b-f703-46c2-b3e6-afdc85483584",
                             "name": "Forbidden",
                             "originalRequest": {
                                 "url": {
@@ -3806,7 +3806,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d0d8bac6-f9c2-48da-8106-f47ba95cb6f7",
+                            "id": "41639bf8-9009-413a-832b-70efa3d05efc",
                             "name": "Not Found",
                             "originalRequest": {
                                 "url": {
@@ -3851,7 +3851,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "dfbc29d9-2f76-4e9a-9207-1a13cc269727",
+                            "id": "8b7ebad8-5bc3-44e0-92fc-161bc3f094d4",
                             "name": "Not Acceptable",
                             "originalRequest": {
                                 "url": {
@@ -3896,7 +3896,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a74adc0e-f292-4569-ba26-8e15f93e96d1",
+                            "id": "57d72fae-3ecb-44bd-a4d0-02f149b12e6d",
                             "name": "Gone",
                             "originalRequest": {
                                 "url": {
@@ -3941,7 +3941,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3878aa0e-0665-4c48-aa85-51e6afa5a0d2",
+                            "id": "b78331e7-c5ea-47b5-9f14-7b009f4e9627",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -3986,7 +3986,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "136c7191-823a-4aea-a0a5-9b9fd9b8460c",
+                            "id": "1e2f849b-7a07-4de0-9595-2e2b2c9d9b2f",
                             "name": "Service Unavailable",
                             "originalRequest": {
                                 "url": {
@@ -4042,14 +4042,14 @@
         {
             "id": "baseUrl",
             "type": "string",
-            "value": "https://api.brk.kadaster.nl/esd/bevragen/v1"
+            "value": "https://api.brk.kadaster.nl/esd-eto-apikey/bevragen/v1"
         }
     ],
     "auth": {
         "type": "noauth"
     },
     "info": {
-        "_postman_id": "d7aac80f-70f8-439d-ad15-b45ee5fe78e7",
+        "_postman_id": "61e0cc38-526d-4ec6-a46d-0d4df435d4a2",
         "name": "Kadaster - BRK-Bevragen API",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
         "description": {


### PR DESCRIPTION
de volgorde van servers in de OAS gewijzigd zodat de eto-apikey bovenaan staat. Dan komt die ook als baseUrl in de gegenereerde postman collection, zodat gebruikers deze direct kunnen gebruiken