### PR TITLE
toevoegen relatie van hypotheek en beslag naar onroerende zaak waar het op rust

### DIFF
--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -1179,6 +1179,9 @@ components:
           description: "De identificaties van de stukdelen (paragrafen in een akte met een rechtsfeit) waarin dit beslag is vermeld"
           items:
             type: "string"
+        onroerendeZaakIdentificatie:
+          type: "string"
+          description: "identificatie van de Kadastraal onroerende zaak waar het beslag op rust"
     BeslagHal:
       allOf:
       - $ref: "#/components/schemas/Beslag"
@@ -1222,6 +1225,8 @@ components:
           type: "array"
           items:
             $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+        rustOpObject:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/schemas/HalLink"
     ErfpachtCanon:
       type: "object"
       description: "Het bedrag dat een erfpachter moet betalen aan de eigenaar van een stuk grond omdat hij zijn grond gebruikt.
@@ -1367,7 +1372,9 @@ components:
           description: "De identificaties van de stukdelen (paragrafen in een akte met een rechtsfeit) waarin deze hypotheek is vermeld"
           items:
             type: "string"
-
+        onroerendeZaakIdentificatie:
+          type: "string"
+          description: "identificatie van de Kadastraal onroerende zaak waar de hypotheek op rust"
     HypotheekHal:
       allOf:
       - $ref: "#/components/schemas/Hypotheek"
@@ -1407,6 +1414,8 @@ components:
           type: "array"
           items:
             $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+        rustOpObject:
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.0.0/api-specificatie/common.yaml#/components/schemas/HalLink"
     KadasterNatuurlijkPersoon:
       allOf:
       - $ref: "#/components/schemas/KadasterPersoon"


### PR DESCRIPTION
toegevoegd zowel identificatie (onroerendeZaakIdentificatie) en link (rustOpObject)

Ik ben er nu vanuitgegaan dat een zekerheidsstelling (beslag of hypotheek) rust op maximaal 1 Kadastraal object (vraag staat nog open in #600 of dit klopt)

Fixes #600