### PR TITLE
ci: commit alleen als er verschillen zijn in genereervariant om git errors te voorkomen

### DIFF
--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -60,8 +60,10 @@ jobs:
           path: specificatie/genereervariant
       - name: push resolved to remote
         run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git add specificatie/genereervariant/openapi.*
-          git commit -m "commit resolve artifacts"
-          git push
+          if [ -n "$(git status specificatie/genereervariant/openapi.yaml --porcelain)" ]; then
+            git config user.name "$GITHUB_ACTOR"
+            git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+            git add specificatie/genereervariant/openapi.*
+            git commit -m "commit resolve artifacts"
+            git push
+          fi

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -6,6 +6,7 @@ on:
       - specificatie/*.yaml
     branches:
       - '**'
+  workflow_dispatch:
 
 jobs:
   validate:


### PR DESCRIPTION
Bij pull requests treden er errors op omdat de genereervariant van een branch meegaan met de pr.
Hierdoor zijn er geen verschillen in de genereervariant van de branch en de genereervariant die wordt gegenereerd in de pr.
Hierdoor is er niets te committen en faalt de git commit.
Een check is toegevoegd om te controleren of er verschillen zijn voordat de git statements wordt uitgevoerd