### PR TITLE
OpenApi.Yaml opgesplitst in kleinere yaml-bestanden

### DIFF
--- a/Releasenotes.md
+++ b/Releasenotes.md
@@ -1,5 +1,15 @@
 # Release notes BRK-Bevragen
 
+## Versie 1.1.1:
+
+Inhoudelijk is er in deze patch niets gewijzigd.
+De structuur van de yaml-bestanden is aangepast omdat het bestand erg groot en overzichtelijk werd.
+Door deze opslitsing is het beheer overzichtelijker en is het werken aan toekomstige wijzigingen beter te managen.
+
+De openapi.yaml in de genereervariant is gewijzigd als gevolg van het gebruiken van een andere generator voor het resolven.
+Deze wijzigingen betreffen hoofdzakelijk volgorde wijzigingen van schemacomponenten.
+Daarnaast zijn er enkele parameter-properties met default-waarden nu expliciet opgenomen in de genereervariant.   
+
 ## Versie 1.1.0:
 
 De repository is opgeschoond. Mappen die overbodig waren zijn verwijderd. De specificatie van de Waardelijsten API is verwijderd omdat die nog niet geïmplementeerd is.

--- a/Releasenotes.md
+++ b/Releasenotes.md
@@ -3,7 +3,7 @@
 ## Versie 1.1.1:
 
 Inhoudelijk is er in deze patch niets gewijzigd.
-De structuur van de yaml-bestanden is aangepast omdat het bestand erg groot en overzichtelijk werd.
+De structuur van de yaml-bestanden is aangepast omdat het bestand erg groot en onoverzichtelijk werd.
 Door deze opslitsing is het beheer overzichtelijker en is het werken aan toekomstige wijzigingen beter te managen.
 
 De openapi.yaml in de genereervariant is gewijzigd als gevolg van het gebruiken van een andere generator voor het resolven.

--- a/specificatie/domain.yaml
+++ b/specificatie/domain.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Kadaster - BRK-Bevragen Components
   description: "De definitie van de components (exclusief de HAL components) die worden gebruikt door de BRK-Bevragen API"
-  version: "1.1.0"
+  version: "1.1.1"
   contact:
     name: Kadaster Haal Centraal BRK-Bevragen
     url: https://github.com/VNG-Realisatie/Haal-Centraal-BRK-Bevragen
@@ -540,4 +540,3 @@ components:
           $ref: "#/components/schemas/Tenaamstelling"
         persoon:
           $ref: "#/components/schemas/PersoonBeperkt"
-

--- a/specificatie/kadaster-natuurlijk-personen.yaml
+++ b/specificatie/kadaster-natuurlijk-personen.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Kadaster - BRK-Bevragen API - Kadaster Natuurlijk Personen endpoints
   description: "De definitie van de Kadaster Natuurlijk Personen endpoints en HAL components"
-  version: "1.1.0"
+  version: "1.1.1"
 paths:
   /kadasternatuurlijkpersonen/{kadasternatuurlijkpersoonidentificatie}:
     get:

--- a/specificatie/kadaster-niet-natuurlijk-personen.yaml
+++ b/specificatie/kadaster-niet-natuurlijk-personen.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Kadaster - BRK-Bevragen API - Kadaster Niet Natuurlijk Personen endpoints
   description: "De definitie van de Kadaster Niet Natuurlijk Personen endpoints en HAL components"
-  version: "1.1.0"
+  version: "1.1.1"
 paths:
   /kadasternietnatuurlijkpersonen/{kadasternietnatuurlijkpersoonidentificatie}:
     get:

--- a/specificatie/kadastraal-onroerende-zaken.yaml
+++ b/specificatie/kadastraal-onroerende-zaken.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Kadaster - BRK-Bevragen API - Kadastraal Onroerende Zaken endpoints
   description: "De definitie van de Kadastraal Onroerende Zaken endpoints en HAL components"
-  version: "1.1.0"
+  version: "1.1.1"
 paths:
   /kadastraalonroerendezaken:
     get:

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -9,7 +9,7 @@ servers:
 info:
   title: Kadaster - BRK-Bevragen API
   description: "D.m.v. deze toepassing worden meerdere, korte bevragingen op de Basis Registratie Kadaster beschikbaar gesteld. Deze toepassing betreft het verstrekken van Kadastrale Onroerende Zaak informatie."
-  version: "1.1.0"
+  version: "1.1.1"
   contact:
     name: Kadaster Haal Centraal BRK-Bevragen
     url: https://github.com/VNG-Realisatie/Haal-Centraal-BRK-Bevragen

--- a/specificatie/zakelijk-gerechtigden.yaml
+++ b/specificatie/zakelijk-gerechtigden.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   title: Kadaster - BRK-Bevragen API - Zakelijk Gerechtigden endpoints
   description: "De definitie van de Zakelijk Gerechtigden endpoints en HAL components"
-  version: "1.1.0"
+  version: "1.1.1"
 paths:
   /kadastraalonroerendezaken/{kadastraalonroerendezaakidentificatie}/zakelijkgerechtigden/{zakelijkgerechtigdeidentificatie}:
     get:


### PR DESCRIPTION
Inhoudelijk is er in deze patch niets gewijzigd.
De structuur van de yaml-bestanden is aangepast omdat het bestand erg groot en overzichtelijk werd.
Door deze opslitsing is het beheer overzichtelijker en is het werken aan toekomstige wijzigingen beter te managen.

De openapi.yaml in de genereervariant is gewijzigd als gevolg van het gebruiken van een andere generator voor het resolven.
Deze wijzigingen betreffen hoofdzakelijk volgorde wijzigingen van schemacomponenten.
Daarnaast zijn er enkele parameter-properties met default-waarden nu expliciet opgenomen in de genereervariant.   