### PR TITLE
Fix typos in features versie 1.2.0

### DIFF
--- a/features/aanhef.feature
+++ b/features/aanhef.feature
@@ -4,12 +4,11 @@ Functionaliteit: Als gemeente wil ik de juiste en consistente briefaanhef in com
   Attribuut "aanhef" bij een natuurlijk persoon wordt gevuld om de persoon op eenduidige wijze te kunnen aanschrijven.
   De aanhef wordt gebruikt bovenaan een brief.
 
-  Attribuut aanschrijfwijze wordt samengesteld op basis van:
+  Attribuut aanhef wordt samengesteld op basis van:
   - adellijkeTitelOfPredikaat
   - aanduidingNaamgebruik
   - naam
     - geslachtsnaam
-    - voornamen
     - voorvoegselsgeslachtsnaam
   - geslacht
     - geslachtsaanduiding
@@ -38,7 +37,7 @@ Functionaliteit: Als gemeente wil ik de juiste en consistente briefaanhef in com
   - N	= Geslachtsnaam echtgenoot/geregistreerd partner na eigen geslachtsnaam
 
   Samenstelling van aanhef voor een persoon zonder adellijke titel of predikaat:
-  | aanduidingNaamgebruik | aanschrijfwijze |
+  | aanduidingNaamgebruik | aanhef          |
   | E                     | AH VV GN        |
   | N                     | AH VV GN-VP GP  |
   | P                     | AH VP GP        |
@@ -63,7 +62,7 @@ Functionaliteit: Als gemeente wil ik de juiste en consistente briefaanhef in com
   | Prins                     | Hoogheid              |
   | Prinses                   | Hoogheid              |
   | Ridder                    | Hoogwelgeboren heer   |
-
+  Waardes van adellijkeTitelOfPredikaat zijn volgens de waardelijst [AdellijkeTitelOfPredikaat](https://www.kadaster.nl/schemas/waardelijsten/AdellijkeTitelOfPredikaat/)
 
   Abstract Scenario: Aanhef
     Als de kadasternatuurlijkpersoon wordt geraadpleegd

--- a/features/aanschrijfwijze.feature
+++ b/features/aanschrijfwijze.feature
@@ -44,7 +44,7 @@ Functionaliteit: Als gemeente wil ik de juiste en consistente aanschrijfwijze va
   | V                     | VL VP GP-PK AT VV GN |
 
   Bij de samenstelling van de aanschrijfwijze volgens bovenstaande tabel gelden de volgende regels:
-  1. Voor adellijke titel en predicaat wordt de Waarde volgens waardelijst "AdellijkeTitelOfPredikaat" gebruikt, geschreven in kleine letters.
+  1. Voor adellijke titel en predikaat wordt de Waarde volgens waardelijst [AdellijkeTitelOfPredikaat](https://www.kadaster.nl/schemas/waardelijsten/AdellijkeTitelOfPredikaat/) gebruikt, geschreven in kleine letters.
   2. Wanneer een naamcomponent geen waarde heeft, wordt ook de spatie erna niet opgenomen.
 
 

--- a/features/gebruik_in_lopende_tekst.feature
+++ b/features/gebruik_in_lopende_tekst.feature
@@ -9,7 +9,6 @@ Functionaliteit: Als gemeente wil ik de juiste en consistent naamgebruik in een 
   - aanduidingNaamgebruik
   - naam
     - geslachtsnaam
-    - voornamen
     - voorvoegselsgeslachtsnaam
   - geslacht
     - geslachtsaanduiding
@@ -39,20 +38,20 @@ Functionaliteit: Als gemeente wil ik de juiste en consistent naamgebruik in een 
 
   Samenstelling van gebruikInLopendeTekst voor een persoon zonder adellijke titel of predikaat:
   | aanduidingNaamgebruik | gebruikInLopendeTekst |
-  | E                     | AH VV GN              |
-  | N                     | AH VV GN-VP GP        |
-  | P                     | AH VP GP              |
-  | V                     | AH VP GP-VV GN        |
+  | E                     | GA VV GN              |
+  | N                     | GA VV GN-VP GP        |
+  | P                     | GA VP GP              |
+  | V                     | GA VP GP-VV GN        |
 
   Samenstelling van gebruikInLopendeTekst voor een persoon met adellijke titel of predikaat:
   | aanduidingNaamgebruik | gebruikInLopendeTekst |
   | E                     | AP VV GN              |
   | N                     | AP VV GN-VP GP        |
-  | P                     | AH VP GP              |
-  | V                     | AH VP GP-AP VV GN     |
+  | P                     | GA VP GP              |
+  | V                     | GA VP GP-AP VV GN     |
 
   Bij de samenstelling van gebruikInLopendeTekst volgens bovenstaande tabel gelden de volgende regels:
-  1. Voor adellijke titel en predicaat wordt de Waarde volgens waardelijst "AdellijkeTitelOfPredikaat" gebruikt, geschreven in kleine letters.
+  1. Voor adellijke titel en predikaat wordt de Waarde volgens waardelijst [AdellijkeTitelOfPredikaat](https://www.kadaster.nl/schemas/waardelijsten/AdellijkeTitelOfPredikaat/) gebruikt, geschreven in kleine letters.
   2. Het voorvoegsel van de eerste geslachtsnaam in gebruikInLopendeTekst wordt met een hoofdletter geschreven.
   3. Wanneer een naamcomponent geen waarde heeft, wordt ook de spatie erna niet opgenomen.
 

--- a/features/voorletters.feature
+++ b/features/voorletters.feature
@@ -6,7 +6,7 @@ Functionaliteit: Bepalen van voorletters uit de voornamen van een persoon
 	Als een voornaam begint met een dubbelklank (Th, Ph, Ch, IJ, enz.), Dan wordt deze voornaam (ook) afgekort tot één voorletter.
 	Als één of meerdere voornamen uit één letter bestaan, dan volgt er na de letter geen "." (punt).
 	Wanneer na een voorletter zonder punt (voornaam had één letter) nog een andere voorletter volgt, wordt daartussen een spatie gezet.
-	Als de rubriek Voornamen is gevuld met de standaardwaarde '.' (punt), Dan wordt geen extra (scheidings)punt toegevoegd; de inhoud van de attribuut voorletters is na afleiding Dan '.'
+	Als voornamen enkel de standaardwaarde '.' (punt) bevat, dan wordt geen extra (scheidings)punt toegevoegd; de voorletters zijn dan '.' (punt).
 
 
 	Abstract Scenario: Voorletters wordt samengesteld uit de eerste letter van de voornamen gescheiden door een punt
@@ -25,3 +25,4 @@ Functionaliteit: Bepalen van voorletters uit de voornamen van een persoon
 		| J P                  | J P         |
 		| Anton B Cornelis     | A.B C.      |
 		| A                    | A           |
+		| .                    | .           |


### PR DESCRIPTION
Naar aanleiding van de implementatie van #375 heb ik typos gefixt in beschrijvingen van:
* `aanhef.feature` 
* `aanschrijfwijze.feature` 
* `gebruik_in_lopende_tekst.feature` 
* `voorletters.feature`. 

---

In het algemeen wordt nu consistent "predikaat" gebruikt en zijn links toegevoegd naar de waardelijst [adellijkeTitelOfPredikaat](https://www.kadaster.nl/schemas/waardelijsten/AdellijkeTitelOfPredikaat/). 
De laatste regel voor het bepalen van de voorletters (".") is verduidelijkt en toegevoegd aan de scenario's.

Tot slot:
• `aanhef.feature` aanschrijfwijze (= aanhef) en voornamen (= niet gebruikt) werden per abuis gebruikt
• `gebruik_in_lopende_tekst.feature` voornamen (= niet gebruikt) en AH (= GA) werden per abuis gebruikt

