### PR TITLE
Wijzigingen aan de Aantekening-structuur n.a.v. #720

### DIFF
--- a/specificatie/beslagen.yaml
+++ b/specificatie/beslagen.yaml
@@ -149,7 +149,7 @@ components:
         aantekeningen:
           type: array
           items:
-            $ref: "domain.yaml#/components/schemas/AantekeningBeperkt"
+            $ref: "domain.yaml#/components/schemas/AantekeningBasis"
             description: |
                           Een aantekening is een verwijzing naar een ter inschrijving aangeboden stuk. Een aantekening op een beslag is theoretisch mogelijk, maar komt bijna niet voor.
         beslagleggers:

--- a/specificatie/beslagen.yaml
+++ b/specificatie/beslagen.yaml
@@ -149,7 +149,7 @@ components:
         aantekeningen:
           type: array
           items:
-            $ref: "domain.yaml#/components/schemas/Aantekening"
+            $ref: "domain.yaml#/components/schemas/AantekeningBeperkt"
             description: |
                           Een aantekening is een verwijzing naar een ter inschrijving aangeboden stuk. Een aantekening op een beslag is theoretisch mogelijk, maar komt bijna niet voor.
         beslagleggers:

--- a/specificatie/domain.yaml
+++ b/specificatie/domain.yaml
@@ -13,7 +13,7 @@ info:
 paths: {}
 components:
   schemas:
-    AantekeningBeperkt:
+    AantekeningBasis:
       type: "object"
       description: |
                     Waardelijst in deze component :
@@ -34,64 +34,26 @@ components:
         betreftGedeelteVanPerceel:
           type: "boolean"
     Aantekening:
-      type: "object"
-      description: |
-                    Waardelijst in deze component :
-                      [aard](http://www.kadaster.nl/schemas/waardelijsten/AardAantekening/)
-      properties:
-        identificatie:
-          type: "string"
-        domein:
-          type: "string"
-          description: |
-                        Het domein waartoe de identificatie behoort.
-        aard:
-          $ref: "#/components/schemas/Waardelijst"
-          description: |
-                        Mogelijke waarden zijn te vinden in deze [Waardelijst](http://www.kadaster.nl/schemas/waardelijsten/AardAantekening/)
-        omschrijving:
-          type: "string"
-        einddatum:
-          type: "string"
-          format: "date"
-        einddatumRecht:
-          type: "string"
-          format: "date"
-        betreftGedeelteVanPerceel:
-          type: "boolean"
+      allOf:
+        - $ref: "#/components/schemas/AantekeningBasis"
+        - properties:
+            einddatum:
+              type: "string"
+              format: "date"
+            einddatumRecht:
+              type: "string"
+              format: "date"
     AantekeningDeprecated:
-      type: "object"
-      description: |
-                    Waardelijst in deze component :
-                      [aard](http://www.kadaster.nl/schemas/waardelijsten/AardAantekening/)
-      properties:
-        identificatie:
-          type: "string"
-        domein:
-          type: "string"
-          description: |
-                        Het domein waartoe de identificatie behoort.
-        aard:
-          $ref: "#/components/schemas/Waardelijst"
-          description: |
-                        Mogelijke waarden zijn te vinden in deze [Waardelijst](http://www.kadaster.nl/schemas/waardelijsten/AardAantekening/)
-        omschrijving:
-          type: "string"
-        begrenzing:
-          allOf:
-            - $ref: "http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/polygonGeoJSON.yaml"
-            - deprecated: true
-        einddatum:
-          type: "string"
-          format: "date"
-        einddatumRecht:
-          type: "string"
-          format: "date"
-        indicatieOorspronkelijkObject:
-          type: "boolean"
-          deprecated: true
-        betreftGedeelteVanPerceel:
-          type: "boolean"
+      allOf:
+        - $ref: "#/components/schemas/Aantekening"
+        - properties:
+            begrenzing:
+              allOf:
+                - $ref: "http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/polygonGeoJSON.yaml"
+                - deprecated: true
+            indicatieOorspronkelijkObject:
+              type: "boolean"
+              deprecated: true
     AdresUitgebreid:
       description: |
                     Waardelijst in deze component :

--- a/specificatie/domain.yaml
+++ b/specificatie/domain.yaml
@@ -13,6 +13,26 @@ info:
 paths: {}
 components:
   schemas:
+    AantekeningBeperkt:
+      type: "object"
+      description: |
+                    Waardelijst in deze component :
+                      [aard](http://www.kadaster.nl/schemas/waardelijsten/AardAantekening/)
+      properties:
+        identificatie:
+          type: "string"
+        domein:
+          type: "string"
+          description: |
+                        Het domein waartoe de identificatie behoort.
+        aard:
+          $ref: "#/components/schemas/Waardelijst"
+          description: |
+                        Mogelijke waarden zijn te vinden in deze [Waardelijst](http://www.kadaster.nl/schemas/waardelijsten/AardAantekening/)
+        omschrijving:
+          type: "string"
+        betreftGedeelteVanPerceel:
+          type: "boolean"
     Aantekening:
       type: "object"
       description: |
@@ -31,8 +51,36 @@ components:
                         Mogelijke waarden zijn te vinden in deze [Waardelijst](http://www.kadaster.nl/schemas/waardelijsten/AardAantekening/)
         omschrijving:
           type: "string"
+        einddatum:
+          type: "string"
+          format: "date"
+        einddatumRecht:
+          type: "string"
+          format: "date"
+        betreftGedeelteVanPerceel:
+          type: "boolean"
+    AantekeningDeprecated:
+      type: "object"
+      description: |
+                    Waardelijst in deze component :
+                      [aard](http://www.kadaster.nl/schemas/waardelijsten/AardAantekening/)
+      properties:
+        identificatie:
+          type: "string"
+        domein:
+          type: "string"
+          description: |
+                        Het domein waartoe de identificatie behoort.
+        aard:
+          $ref: "#/components/schemas/Waardelijst"
+          description: |
+                        Mogelijke waarden zijn te vinden in deze [Waardelijst](http://www.kadaster.nl/schemas/waardelijsten/AardAantekening/)
+        omschrijving:
+          type: "string"
         begrenzing:
-          $ref: "http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/polygonGeoJSON.yaml"
+          allOf:
+            - $ref: "http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/polygonGeoJSON.yaml"
+            - deprecated: true
         einddatum:
           type: "string"
           format: "date"
@@ -44,7 +92,6 @@ components:
           deprecated: true
         betreftGedeelteVanPerceel:
           type: "boolean"
-
     AdresUitgebreid:
       description: |
                     Waardelijst in deze component :
@@ -210,8 +257,9 @@ components:
                       Een bij het kadaster geregistreerde niet natuurlijke persoon, al dan niet ingeschreven in het handelsregister. Kadasternietnatuurlijkpersonen worden niet geactualiseerd.
 
 
+                      De property beschikkingsbevoegdheid is bij een KadasterNietNatuurlijkPersoon nooit gevuld.
                       Waardelijst in deze component :
-                        [beschikkingsbevoegdheid](http://www.kadaster.nl/schemas/waardelijsten/Beschikkingsbevoegdheid/) en [rechtsvorm](http://www.kadaster.nl/schemas/waardelijsten/Rechtsvorm/)
+                        [rechtsvorm](http://www.kadaster.nl/schemas/waardelijsten/Rechtsvorm/)
         properties:
           statutaireNaam:
             type: "string"
@@ -479,7 +527,7 @@ components:
           description: |
                         Een aantekening is een verwijzing naar een ter inschrijving aangeboden stuk. Een aantekening op een tenaamstelling van een zakelijk recht is meestal een beperking. Bijvoorbeeld de verkrijging van een aandeel in een zakelijk recht onder opschortende voorwaarde, een beperking van de handelingsbevoegdheid van de zakelijk gerechtigde, of een koopovereenkomst
           items:
-            $ref: "#/components/schemas/Aantekening"
+            $ref: "#/components/schemas/AantekeningDeprecated"
         gezamenlijkAandeel:
           $ref: "#/components/schemas/TypeBreuk"
           description: |

--- a/specificatie/hypotheken.yaml
+++ b/specificatie/hypotheken.yaml
@@ -145,7 +145,7 @@ components:
         aantekeningen:
           type: array
           items:
-            $ref: "domain.yaml#/components/schemas/Aantekening"
+            $ref: "domain.yaml#/components/schemas/AantekeningBeperkt"
             description: |
                           Een aantekening is een verwijzing naar een ter inschrijving aangeboden stuk. Een aantekening op een hypotheek is bijvoorbeeld een rangwisseling hypotheek, waarbij een hypotheek voorrang heeft boven eerder ingeschreven hypotheken of rechten op dezelfde kadastraal onroerende zaak.
         hypotheekhouders:

--- a/specificatie/hypotheken.yaml
+++ b/specificatie/hypotheken.yaml
@@ -145,7 +145,7 @@ components:
         aantekeningen:
           type: array
           items:
-            $ref: "domain.yaml#/components/schemas/AantekeningBeperkt"
+            $ref: "domain.yaml#/components/schemas/AantekeningBasis"
             description: |
                           Een aantekening is een verwijzing naar een ter inschrijving aangeboden stuk. Een aantekening op een hypotheek is bijvoorbeeld een rangwisseling hypotheek, waarbij een hypotheek voorrang heeft boven eerder ingeschreven hypotheken of rechten op dezelfde kadastraal onroerende zaak.
         hypotheekhouders:


### PR DESCRIPTION
Ik heb de componentnamen "AntekeningBeperkt",  "Aantekening"  en "AantekeningDeprecated". Ik sta open voor verbetervoorstellen.

Verder is begrenzing een ref naar een opengisdefinitie. Daar mag geen sibling naast. Ik heeb dus de deprecated toegevoegd met een allOf. @MelvLee : wil jij checken of dat codegeneratie-issues geeft ? Ook hier ben ik benieuwd of iemand een betere constructiue weet. 