### PR TITLE
Velden datumSluiting en datumOntbinding op deprecated van Partnerschap

### DIFF
--- a/specificatie/domain.yaml
+++ b/specificatie/domain.yaml
@@ -176,13 +176,13 @@ components:
                     Partnerschap is een groep gegevens over de huwelijkse- of partnerschapstatus van een persoon.
       properties:
         datumOntbinding:
+          deprecated: true
           allOf:
             - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
-            - deprecated: true
         datumSluiting:
+          deprecated: true
           allOf:
             - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
-            - deprecated: true
         naam:
           $ref: "#/components/schemas/Naam"
     KadasterNatuurlijkPersoon:

--- a/specificatie/domain.yaml
+++ b/specificatie/domain.yaml
@@ -48,9 +48,9 @@ components:
         - $ref: "#/components/schemas/Aantekening"
         - properties:
             begrenzing:
+              deprecated: true
               allOf:
                 - $ref: "http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/polygonGeoJSON.yaml"
-                - deprecated: true
             indicatieOorspronkelijkObject:
               type: "boolean"
               deprecated: true

--- a/specificatie/domain.yaml
+++ b/specificatie/domain.yaml
@@ -176,9 +176,13 @@ components:
                     Partnerschap is een groep gegevens over de huwelijkse- of partnerschapstatus van een persoon.
       properties:
         datumOntbinding:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          allOf:
+            - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+            - deprecated: true
         datumSluiting:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+          allOf:
+            - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/DatumOnvolledig"
+            - deprecated: true
         naam:
           $ref: "#/components/schemas/Naam"
     KadasterNatuurlijkPersoon:

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -5016,17 +5016,15 @@
         "type" : "object",
         "properties" : {
           "datumOntbinding" : {
+            "deprecated" : true,
             "allOf" : [ {
               "$ref" : "#/components/schemas/DatumOnvolledig"
-            }, {
-              "deprecated" : true
             } ]
           },
           "datumSluiting" : {
+            "deprecated" : true,
             "allOf" : [ {
               "$ref" : "#/components/schemas/DatumOnvolledig"
-            }, {
-              "deprecated" : true
             } ]
           },
           "naam" : {

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -4807,10 +4807,9 @@
         }, {
           "properties" : {
             "begrenzing" : {
+              "deprecated" : true,
               "allOf" : [ {
                 "$ref" : "#/components/schemas/polygonGeoJSON"
-              }, {
-                "deprecated" : true
               } ]
             },
             "indicatieOorspronkelijkObject" : {

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -3976,13 +3976,13 @@ components:
       type: object
       properties:
         datumOntbinding:
+          deprecated: true
           allOf:
           - $ref: '#/components/schemas/DatumOnvolledig'
-          - deprecated: true
         datumSluiting:
+          deprecated: true
           allOf:
           - $ref: '#/components/schemas/DatumOnvolledig'
-          - deprecated: true
         naam:
           $ref: '#/components/schemas/Naam'
       description: |

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -3801,9 +3801,9 @@ components:
       - $ref: '#/components/schemas/Aantekening'
       - properties:
           begrenzing:
+            deprecated: true
             allOf:
             - $ref: '#/components/schemas/polygonGeoJSON'
-            - deprecated: true
           indicatieOorspronkelijkObject:
             type: boolean
             deprecated: true


### PR DESCRIPTION
De velden datumSluiting en datumOntbinding zullen worden verwijderd in een toekomstige versie van IMKAD. 
Hierop heeft onze bron al voorgesorteerd en deze levert nu al deze velden niet meer.
Mijn voorstel is om deze velden als deprecated te markeren, zodat we deze ook kunnen uitfaseren in een toekomstige release.

@JohanBoer: kun jij nagaan of ik het zo goed heb gedaan met het toevoegen van de deprecated param?
