### PR TITLE
Aanpassingen n.a.v. bepreking 18-11 doorgevoerd

### DIFF
--- a/specificatie/domain.yaml
+++ b/specificatie/domain.yaml
@@ -436,7 +436,7 @@ components:
           $ref: "#/components/schemas/Waardelijst"
           description: |
                           Mogelijke waarden zijn te vinden in deze [Waardelijst](http://www.kadaster.nl/schemas/waardelijsten/AardKadasterverzoek/)
-        RedenenVerzoek:
+        redenenVerzoek:
           type: "array"
           items:
             $ref: "#/components/schemas/RedenVerzoek"
@@ -594,38 +594,49 @@ components:
         identificatie:
           type: "string"
         stukType:
-          $ref: "#/components/schemas/StukType_enum"
+          $ref: "#/components/schemas/StukTypeEnum"
         domein:
           type: "string"
-          description: "Het domein waartoe de identificatie behoort."
+          description: |
+                        Het domein waartoe de identificatie behoort.
         toelichtingBewaarder:
           type: "string"
-          description: "Toelichtende tekst bij een onroerende zaak van de bewaarder. De bewaarder is iemand die bij het Kadaster werkt. Hij schrijft stukken in in de openbare registers en de basisregistratie Kadaster conform de Kadasterwet."
+          description: |
+                        Toelichtende tekst bij een onroerende zaak van de bewaarder.
+                        De bewaarder is iemand die bij het Kadaster werkt.
+                        Hij schrijft stukken in in de openbare registers en de basisregistratie Kadaster conform de Kadasterwet.
         stukdeelIdentificaties:
           type: "array"
           items:
             type: "string"
         bewaardersVerklaring:
           type: "string"
-          description: "Correctie in de openbare registers door de bewaarder. De bewaarder is iemand die bij het Kadaster werkt. Hij schrijft stukken in in de openbare registers en de basisregistratie Kadaster conform de Kadasterwet."
+          description: |
+                        Correctie in de openbare registers door de bewaarder.
+                        De bewaarder is iemand die bij het Kadaster werkt.
+                        Hij schrijft stukken in in de openbare registers en de basisregistratie Kadaster conform de Kadasterwet.
         tekeningIngeschreven:
           type: "boolean"
-          description: "Er is sprake van een appartementstekening (splitsingstekening\
-            \ van appartementen) als bijlage bij het stuk."
+          description: |
+                        Geeft aan dat er een tekening van het appartement als bijlage bij het stuk aanwezig is.
         tijdstipAanbieding:
           type: "string"
           format: "date-time"
-          description: "Het tijdstip dat het stuk bij het kadaster is binnengekomen."
+          description: |
+                        Het tijdstip dat het stuk bij het kadaster is binnengekomen.
         tijdstipOndertekening:
           type: "string"
           format: "date-time"
-          description: "Het tijdstip dat het stuk is ondertekend door partijen en de notaris"
+          description: |
+                        Het tijdstip dat het stuk is ondertekend door partijen en de notaris
         aard:
           $ref: "#/components/schemas/Waardelijst"
-          description: "Mogelijke waarden zijn te vinden in deze [Waardelijst](http://www.kadaster.nl/schemas/waardelijsten/AardAangebodenStuk/)"
+          description: |
+                        Mogelijke waarden zijn te vinden in deze [Waardelijst](http://www.kadaster.nl/schemas/waardelijsten/AardAangebodenStuk/)
         status:
           $ref: "#/components/schemas/Waardelijst"
-          description: "Mogelijke waarden zijn te vinden in deze [Waardelijst](http://www.kadaster.nl/schemas/waardelijsten/StatusStukOR/)"
+          description: |
+                        Mogelijke waarden zijn te vinden in deze [Waardelijst](http://www.kadaster.nl/schemas/waardelijsten/StatusStukOR/)
         equivalentieVerklaarder:
           $ref: "#/components/schemas/EquivalentieVerklaarder"
         kadasterverzoeken:
@@ -633,28 +644,33 @@ components:
           items:
             $ref: "#/components/schemas/Kadasterverzoek"
         oorspronkelijkStukIdentificatie:
-          description: "Referentie naar het het aangeboden stuk waarop de correctie heeft plaatsgevonden die middels dit Kadasterstuk heeft geleid tot een aanpassing in de BasisRegistratie Kadaster"
+          description: |
+                        Referentie naar het het aangeboden stuk waarop de correctie heeft plaatsgevonden die middels dit Kadasterstuk heeft geleid tot een aanpassing in de BasisRegistratie Kadaster
           type: "string"
     Stukdeel:
       type: object
-      description: "Een stukdeel is een paragraaf in een akte waarmee een recht gevestigd wordt."
+      description: |
+                    Een stukdeel is een paragraaf in een akte waarmee een recht gevestigd wordt.
       properties:
         identificatie:
           type: "string"
         domein:
           type: "string"
-          description: "Het domein waartoe de identificatie behoort."
+          description: |
+                        Het domein waartoe de identificatie behoort.
         aard:
           $ref: "#/components/schemas/Waardelijst"
-          description: "Mogelijke waarden zijn te vinden in deze [Waardelijst](http://www.kadaster.nl/schemas/waardelijsten/AardStukdeel/)"
+          description: |
+                        Mogelijke waarden zijn te vinden in deze [Waardelijst](http://www.kadaster.nl/schemas/waardelijsten/AardStukdeel/)
         bedragTransactiesomLevering:
           $ref: "#/components/schemas/Bedrag"
-          description: "De koopsom"
+          description: |
+                        De koopsom
         omschrijvingKadastraleObjecten:
             type: "string"
         omschrijvingTopografischeMutatie:
             type: "string"
-    StukType_enum:
+    StukTypeEnum:
       type: "string"
       enum:
       - "Kadasterstuk"

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -42,8 +42,6 @@
     "name" : "Kadaster (niet)Natuurlijk Personen"
   }, {
     "name" : "Stukken (Akte)"
-  }, {
-    "name" : "Stukdelen"
   } ],
   "paths" : {
     "/kadastraalonroerendezaken" : {
@@ -4026,7 +4024,7 @@
     },
     "/stukdelen/{stukdeelidentificatie}" : {
       "get" : {
-        "tags" : [ "Stukdelen" ],
+        "tags" : [ "Stukken (Akte)" ],
         "description" : "Raadplegen van een stukdeel. In een akte (stuk) zijn meerdere rechtsfeiten (stukdelen) vastgelegd.\nMet de stukdeel-identificaties kunnen gegevens over het stukdeel worden opgevraagd.\n",
         "operationId" : "GetStukdeel",
         "parameters" : [ {
@@ -4406,12 +4404,6 @@
             "items" : {
               "$ref" : "#/components/schemas/PrivaatrechtelijkeBeperkingHal"
             }
-          },
-          "stukken" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/StukHalBasis"
-            }
           }
         }
       },
@@ -4532,10 +4524,7 @@
             }
           },
           "isGebaseerdOpStukdeel" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/HalLink"
-            }
+            "$ref" : "#/components/schemas/HalLink"
           },
           "isVermeldInStukdelen" : {
             "type" : "array",
@@ -4563,18 +4552,6 @@
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/ZakelijkGerechtigdeHal"
-            }
-          },
-          "stukken" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/StukHalBasis"
-            }
-          },
-          "stukdelen" : {
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/StukdeelHalBasis"
             }
           }
         }
@@ -5038,6 +5015,13 @@
           "bevoegdGezag" : {
             "$ref" : "#/components/schemas/NietNatuurlijkPersoonBeperkt"
           },
+          "Stukken" : {
+            "type" : "array",
+            "description" : "Dit element is de identificatie van het Stuk. Dit kan een aangeboden Stuk of een Kadasterstuk zijn.\n",
+            "items" : {
+              "type" : "string"
+            }
+          },
           "isGebaseerdOpStukdeelIdentificatie" : {
             "type" : "string",
             "description" : "De identificatie van het stukdeel (paragraaf in een akte met een rechtsfeit) waarop deze publiekrechtelijke beperking is gebaseerd.\n"
@@ -5057,6 +5041,12 @@
         "properties" : {
           "bevoegdGezag" : {
             "$ref" : "#/components/schemas/HalLink"
+          },
+          "stukken" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/HalLink"
+            }
           },
           "isGebaseerdOpStukdeel" : {
             "$ref" : "#/components/schemas/HalLink"
@@ -5983,15 +5973,15 @@
             "type" : "string"
           },
           "stukType" : {
-            "$ref" : "#/components/schemas/StukType_enum"
+            "$ref" : "#/components/schemas/StukTypeEnum"
           },
           "domein" : {
             "type" : "string",
-            "description" : "Het domein waartoe de identificatie behoort."
+            "description" : "Het domein waartoe de identificatie behoort.\n"
           },
           "toelichtingBewaarder" : {
             "type" : "string",
-            "description" : "Toelichtende tekst bij een onroerende zaak van de bewaarder. De bewaarder is iemand die bij het Kadaster werkt. Hij schrijft stukken in in de openbare registers en de basisregistratie Kadaster conform de Kadasterwet."
+            "description" : "Toelichtende tekst bij een onroerende zaak van de bewaarder.\nDe bewaarder is iemand die bij het Kadaster werkt.\nHij schrijft stukken in in de openbare registers en de basisregistratie Kadaster conform de Kadasterwet.\n"
           },
           "stukdeelIdentificaties" : {
             "type" : "array",
@@ -6001,20 +5991,20 @@
           },
           "bewaardersVerklaring" : {
             "type" : "string",
-            "description" : "Correctie in de openbare registers door de bewaarder. De bewaarder is iemand die bij het Kadaster werkt. Hij schrijft stukken in in de openbare registers en de basisregistratie Kadaster conform de Kadasterwet."
+            "description" : "Correctie in de openbare registers door de bewaarder.\nDe bewaarder is iemand die bij het Kadaster werkt.\nHij schrijft stukken in in de openbare registers en de basisregistratie Kadaster conform de Kadasterwet.\n"
           },
           "tekeningIngeschreven" : {
             "type" : "boolean",
-            "description" : "Er is sprake van een appartementstekening (splitsingstekening van appartementen) als bijlage bij het stuk."
+            "description" : "Geeft aan dat er een tekening van het appartement als bijlage bij het stuk aanwezig is.\n"
           },
           "tijdstipAanbieding" : {
             "type" : "string",
-            "description" : "Het tijdstip dat het stuk bij het kadaster is binnengekomen.",
+            "description" : "Het tijdstip dat het stuk bij het kadaster is binnengekomen.\n",
             "format" : "date-time"
           },
           "tijdstipOndertekening" : {
             "type" : "string",
-            "description" : "Het tijdstip dat het stuk is ondertekend door partijen en de notaris",
+            "description" : "Het tijdstip dat het stuk is ondertekend door partijen en de notaris\n",
             "format" : "date-time"
           },
           "aard" : {
@@ -6034,12 +6024,12 @@
           },
           "oorspronkelijkStukIdentificatie" : {
             "type" : "string",
-            "description" : "Referentie naar het het aangeboden stuk waarop de correctie heeft plaatsgevonden die middels dit Kadasterstuk heeft geleid tot een aanpassing in de BasisRegistratie Kadaster"
+            "description" : "Referentie naar het het aangeboden stuk waarop de correctie heeft plaatsgevonden die middels dit Kadasterstuk heeft geleid tot een aanpassing in de BasisRegistratie Kadaster\n"
           }
         },
         "description" : "Hieraan wordt een Kadasterstuk of een Aangebodenstuk gekoppeld. Een stuk is een brondocument dat aanleiding geeft tot een wijziging van de gegevens in een basisregistratie. Een aangeboden brondocument dat aanleiding geeft tot een wijziging van de gegevens in een basisregistratie.\nWaardelijsten in deze component :\n  [aard](http://www.kadaster.nl/schemas/waardelijsten/AardAangebodenStuk/) en\n  [status](http://www.kadaster.nl/schemas/waardelijsten/StatusStukOR/)\"\n"
       },
-      "StukType_enum" : {
+      "StukTypeEnum" : {
         "type" : "string",
         "enum" : [ "Kadasterstuk", "Aangebodenstuk" ]
       },
@@ -6063,7 +6053,7 @@
           "aard" : {
             "$ref" : "#/components/schemas/Waardelijst"
           },
-          "RedenenVerzoek" : {
+          "redenenVerzoek" : {
             "type" : "array",
             "items" : {
               "$ref" : "#/components/schemas/RedenVerzoek"
@@ -6093,7 +6083,7 @@
           },
           "domein" : {
             "type" : "string",
-            "description" : "Het domein waartoe de identificatie behoort."
+            "description" : "Het domein waartoe de identificatie behoort.\n"
           },
           "aard" : {
             "$ref" : "#/components/schemas/Waardelijst"
@@ -6108,7 +6098,7 @@
             "type" : "string"
           }
         },
-        "description" : "Een stukdeel is een paragraaf in een akte waarmee een recht gevestigd wordt."
+        "description" : "Een stukdeel is een paragraaf in een akte waarmee een recht gevestigd wordt.\n"
       }
     },
     "headers" : {

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -31,14 +31,13 @@ tags:
 - name: Publiekrechtelijke Beperkingen
 - name: Kadaster (niet)Natuurlijk Personen
 - name: Stukken (Akte)
-- name: Stukdelen
 paths:
   /kadastraalonroerendezaken:
     get:
       tags:
       - Kadastraal Onroerende Zaken
       description: |
-        Het zoeken van kadastraal onroerende zaken door exact één van de volgende categorieën parameters op te geven. Het combineren van parameters uit verschillende categorieën is niet toegestaan.
+        Het zoeken van kadastraal onroerende zaken door exact één van de volgende categorieën parameters op te geven. Het combineren van parameters uit verschillende categorieön is niet toegestaan.
         1.  Kadastrale aanduiding
         2.  Ingeschreven persoon als zakelijk gerechtigde
             -  burgerservicenummer (verplicht)
@@ -2639,8 +2638,8 @@ paths:
                   to a temporary overloading or maintenance of the server.
                 instance: https://datapunt.voorbeeldgemeente.nl/api/v1/resourcenaam?parameter=waarde
                 code: notAvailable
-  ? /kadastraalonroerendezaken/{kadastraalonroerendezaakidentificatie}/privaatrechtelijkebeperkingen/{privaatrechtelijkebeperkingidentificatie}
-  : get:
+  /kadastraalonroerendezaken/{kadastraalonroerendezaakidentificatie}/privaatrechtelijkebeperkingen/{privaatrechtelijkebeperkingidentificatie}:
+    get:
       tags:
       - Privaatrechtelijke Beperkingen
       description: |
@@ -3179,7 +3178,7 @@ paths:
   /stukdelen/{stukdeelidentificatie}:
     get:
       tags:
-      - Stukdelen
+      - Stukken (Akte)
       description: |
         Raadplegen van een stukdeel. In een akte (stuk) zijn meerdere rechtsfeiten (stukdelen) vastgelegd.
         Met de stukdeel-identificaties kunnen gegevens over het stukdeel worden opgevraagd.
@@ -3459,10 +3458,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PrivaatrechtelijkeBeperkingHal'
-        stukken:
-          type: array
-          items:
-            $ref: '#/components/schemas/StukHalBasis'
     TypeGerechtigdeEnum:
       type: string
       description: |
@@ -3581,9 +3576,7 @@ components:
           items:
             $ref: '#/components/schemas/HalLink'
         isGebaseerdOpStukdeel:
-          type: array
-          items:
-            $ref: '#/components/schemas/HalLink'
+          $ref: '#/components/schemas/HalLink'
         isVermeldInStukdelen:
           type: array
           items:
@@ -3602,14 +3595,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ZakelijkGerechtigdeHal'
-        stukken:
-          type: array
-          items:
-            $ref: '#/components/schemas/StukHalBasis'
-        stukdelen:
-          type: array
-          items:
-            $ref: '#/components/schemas/StukdeelHalBasis'
     KadasterNatuurlijkPersoonHal:
       allOf:
       - $ref: '#/components/schemas/KadasterNatuurlijkPersoon'
@@ -3933,6 +3918,12 @@ components:
           format: date
         bevoegdGezag:
           $ref: '#/components/schemas/NietNatuurlijkPersoonBeperkt'
+        Stukken:
+          type: array
+          description: |
+            Dit element is de identificatie van het Stuk. Dit kan een aangeboden Stuk of een Kadasterstuk zijn.
+          items:
+            type: string
         isGebaseerdOpStukdeelIdentificatie:
           type: string
           description: |
@@ -3950,6 +3941,10 @@ components:
       properties:
         bevoegdGezag:
           $ref: '#/components/schemas/HalLink'
+        stukken:
+          type: array
+          items:
+            $ref: '#/components/schemas/HalLink'
         isGebaseerdOpStukdeel:
           $ref: '#/components/schemas/HalLink'
         isVermeldInStukdelen:
@@ -4742,37 +4737,40 @@ components:
         identificatie:
           type: string
         stukType:
-          $ref: '#/components/schemas/StukType_enum'
+          $ref: '#/components/schemas/StukTypeEnum'
         domein:
           type: string
-          description: Het domein waartoe de identificatie behoort.
+          description: |
+            Het domein waartoe de identificatie behoort.
         toelichtingBewaarder:
           type: string
-          description: Toelichtende tekst bij een onroerende zaak van de bewaarder.
-            De bewaarder is iemand die bij het Kadaster werkt. Hij schrijft stukken
-            in in de openbare registers en de basisregistratie Kadaster conform de
-            Kadasterwet.
+          description: |
+            Toelichtende tekst bij een onroerende zaak van de bewaarder.
+            De bewaarder is iemand die bij het Kadaster werkt.
+            Hij schrijft stukken in in de openbare registers en de basisregistratie Kadaster conform de Kadasterwet.
         stukdeelIdentificaties:
           type: array
           items:
             type: string
         bewaardersVerklaring:
           type: string
-          description: Correctie in de openbare registers door de bewaarder. De bewaarder
-            is iemand die bij het Kadaster werkt. Hij schrijft stukken in in de openbare
-            registers en de basisregistratie Kadaster conform de Kadasterwet.
+          description: |
+            Correctie in de openbare registers door de bewaarder.
+            De bewaarder is iemand die bij het Kadaster werkt.
+            Hij schrijft stukken in in de openbare registers en de basisregistratie Kadaster conform de Kadasterwet.
         tekeningIngeschreven:
           type: boolean
-          description: Er is sprake van een appartementstekening (splitsingstekening
-            van appartementen) als bijlage bij het stuk.
+          description: |
+            Geeft aan dat er een tekening van het appartement als bijlage bij het stuk aanwezig is.
         tijdstipAanbieding:
           type: string
-          description: Het tijdstip dat het stuk bij het kadaster is binnengekomen.
+          description: |
+            Het tijdstip dat het stuk bij het kadaster is binnengekomen.
           format: date-time
         tijdstipOndertekening:
           type: string
-          description: Het tijdstip dat het stuk is ondertekend door partijen en de
-            notaris
+          description: |
+            Het tijdstip dat het stuk is ondertekend door partijen en de notaris
           format: date-time
         aard:
           $ref: '#/components/schemas/Waardelijst'
@@ -4786,15 +4784,14 @@ components:
             $ref: '#/components/schemas/Kadasterverzoek'
         oorspronkelijkStukIdentificatie:
           type: string
-          description: Referentie naar het het aangeboden stuk waarop de correctie
-            heeft plaatsgevonden die middels dit Kadasterstuk heeft geleid tot een
-            aanpassing in de BasisRegistratie Kadaster
+          description: |
+            Referentie naar het het aangeboden stuk waarop de correctie heeft plaatsgevonden die middels dit Kadasterstuk heeft geleid tot een aanpassing in de BasisRegistratie Kadaster
       description: |
         Hieraan wordt een Kadasterstuk of een Aangebodenstuk gekoppeld. Een stuk is een brondocument dat aanleiding geeft tot een wijziging van de gegevens in een basisregistratie. Een aangeboden brondocument dat aanleiding geeft tot een wijziging van de gegevens in een basisregistratie.
         Waardelijsten in deze component :
           [aard](http://www.kadaster.nl/schemas/waardelijsten/AardAangebodenStuk/) en
           [status](http://www.kadaster.nl/schemas/waardelijsten/StatusStukOR/)"
-    StukType_enum:
+    StukTypeEnum:
       type: string
       enum:
       - Kadasterstuk
@@ -4816,7 +4813,7 @@ components:
       properties:
         aard:
           $ref: '#/components/schemas/Waardelijst'
-        RedenenVerzoek:
+        redenenVerzoek:
           type: array
           items:
             $ref: '#/components/schemas/RedenVerzoek'
@@ -4845,7 +4842,8 @@ components:
           type: string
         domein:
           type: string
-          description: Het domein waartoe de identificatie behoort.
+          description: |
+            Het domein waartoe de identificatie behoort.
         aard:
           $ref: '#/components/schemas/Waardelijst'
         bedragTransactiesomLevering:
@@ -4854,8 +4852,8 @@ components:
           type: string
         omschrijvingTopografischeMutatie:
           type: string
-      description: Een stukdeel is een paragraaf in een akte waarmee een recht gevestigd
-        wordt.
+      description: |
+        Een stukdeel is een paragraaf in een akte waarmee een recht gevestigd wordt.
   headers:
     api_version:
       schema:

--- a/specificatie/kadastraal-onroerende-zaken.yaml
+++ b/specificatie/kadastraal-onroerende-zaken.yaml
@@ -264,8 +264,3 @@ components:
               type: "array"
               items:
                 $ref: "privaat-rechtelijke-beperkingen.yaml#/components/schemas/PrivaatrechtelijkeBeperkingHal"
-            stukken:
-              type: "array"
-              items:
-                $ref: "stukken.yaml#/components/schemas/StukHalBasis"
-

--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -31,7 +31,6 @@ tags:
 - name: Publiekrechtelijke Beperkingen
 - name: Kadaster (niet)Natuurlijk Personen
 - name: Stukken (Akte)
-- name: Stukdelen
 paths:
   /kadastraalonroerendezaken:
     $ref: "kadastraal-onroerende-zaken.yaml#/paths/~1kadastraalonroerendezaken"

--- a/specificatie/publiek-rechtelijke-beperkingen.yaml
+++ b/specificatie/publiek-rechtelijke-beperkingen.yaml
@@ -71,6 +71,12 @@ components:
           format: "date"
         bevoegdGezag:
           $ref: "domain.yaml#/components/schemas/NietNatuurlijkPersoonBeperkt"
+        Stukken:
+          type: "array"
+          description: |
+                        Dit element is de identificatie van het Stuk. Dit kan een aangeboden Stuk of een Kadasterstuk zijn.
+          items:
+            type: "string"
         isGebaseerdOpStukdeelIdentificatie:
           type: "string"
           description: |
@@ -106,6 +112,10 @@ components:
       properties:
         bevoegdGezag:
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+        stukken:
+          type: "array"
+          items:
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         isGebaseerdOpStukdeel:
             $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         isVermeldInStukdelen:

--- a/specificatie/stukken.yaml
+++ b/specificatie/stukken.yaml
@@ -94,7 +94,7 @@ paths:
         '503':
           $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/responses/503"
       tags:
-        - Stukdelen
+      - Stukken (Akte)
 components:
   schemas:
     StukdeelHalBasis:

--- a/specificatie/zakelijk-gerechtigden.yaml
+++ b/specificatie/zakelijk-gerechtigden.yaml
@@ -141,9 +141,7 @@ components:
           items:
             $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         isGebaseerdOpStukdeel:
-          type: "array"
-          items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         isVermeldInStukdelen:
           type: "array"
           items:
@@ -162,11 +160,3 @@ components:
           type: "array"
           items:
             $ref: "#/components/schemas/ZakelijkGerechtigdeHal"
-        stukken:
-          type: "array"
-          items:
-            $ref: "stukken.yaml#/components/schemas/StukHalBasis"
-        stukdelen:
-          type: "array"
-          items:
-            $ref: "stukken.yaml#/components/schemas/StukdeelHalBasis"

--- a/test/BRK-Bevragen-postman-collection.json
+++ b/test/BRK-Bevragen-postman-collection.json
@@ -1,16 +1,16 @@
 {
     "item": [
         {
-            "id": "c31cb320-4bd8-42d1-af39-03b6c87c4e3d",
+            "id": "e13c456a-d847-492e-b6eb-6c56d9a711f1",
             "name": "kadastraalonroerendezaken",
             "item": [
                 {
-                    "id": "ca116552-d715-40b2-bdfe-9827462ef3fa",
+                    "id": "923d081f-3baa-4ee1-a719-6a114b170fea",
                     "name": "Get Kadastraal Onroerende Zaken",
                     "request": {
                         "name": "Get Kadastraal Onroerende Zaken",
                         "description": {
-                            "content": "Het zoeken van kadastraal onroerende zaken door exact één van de volgende categorieën parameters op te geven. Het combineren van parameters uit verschillende categorieën is niet toegestaan.\n1.  Kadastrale aanduiding\n2.  Ingeschreven persoon als zakelijk gerechtigde\n    -  burgerservicenummer (verplicht)\n    -  typegerechtigde (optioneel)\n3.  Niet ingeschreven persoon of niet natuurlijk persoon als zakelijk gerechtigde\n    -  kadasterpersoonidentificatie (verplicht)\n    -  typegerechtigde (optioneel)\n4.  Adres\n    -  postcode (verplicht)\n    -  huisnummer (optioneel)\n    -  huisletter (optioneel)\n    -  huisnummertoevoeging (optioneel)\n\nMet gebruik van de parameter expand kunnen zakelijkgerechtigden direct worden meegeladen.\n\nHet maximale aantal zoekresultaten dat geretourneerd wordt is aan de provider om te bepalen. Als het resultaat van de de request dit aantal overtreft worden er geen resultaten geretourneerd en volgt er een foutmelding.\n",
+                            "content": "Het zoeken van kadastraal onroerende zaken door exact één van de volgende categorieën parameters op te geven. Het combineren van parameters uit verschillende categorieön is niet toegestaan.\n1.  Kadastrale aanduiding\n2.  Ingeschreven persoon als zakelijk gerechtigde\n    -  burgerservicenummer (verplicht)\n    -  typegerechtigde (optioneel)\n3.  Niet ingeschreven persoon of niet natuurlijk persoon als zakelijk gerechtigde\n    -  kadasterpersoonidentificatie (verplicht)\n    -  typegerechtigde (optioneel)\n4.  Adres\n    -  postcode (verplicht)\n    -  huisnummer (optioneel)\n    -  huisletter (optioneel)\n    -  huisnummertoevoeging (optioneel)\n\nMet gebruik van de parameter expand kunnen zakelijkgerechtigden direct worden meegeladen.\n\nHet maximale aantal zoekresultaten dat geretourneerd wordt is aan de provider om te bepalen. Als het resultaat van de de request dit aantal overtreft worden er geen resultaten geretourneerd en volgt er een foutmelding.\n",
                             "type": "text/plain"
                         },
                         "url": {
@@ -86,7 +86,7 @@
                     },
                     "response": [
                         {
-                            "id": "9db9f84a-fcf0-4a15-aed1-9cdf00d157f0",
+                            "id": "2bcf6db2-be2a-4f49-a369-4222b6afad66",
                             "name": "Zoekactie geslaagd\n",
                             "originalRequest": {
                                 "url": {
@@ -181,12 +181,12 @@
                                     "value": "application/hal+json"
                                 }
                             ],
-                            "body": "{\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"in adipisicing velit et\"\n  }\n },\n \"_embedded\": {\n  \"kadastraalOnroerendeZaken\": [\n   {\n    \"identificatie\": \"nostrud culpa eu\",\n    \"domein\": \"proident dolor\",\n    \"begrenzingPerceel\": {\n     \"coordinates\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"type\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"perceelnummerRotatie\": -71735443.35383824,\n    \"plaatscoordinaten\": {\n     \"coordinates\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"type\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"koopsom\": {\n     \"koopsom\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"koopjaar\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"indicatieMetMeerObjectenVerkregen\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"toelichtingBewaarder\": \"ullamco quis laborum\",\n    \"type\": \"appartementsrecht\",\n    \"aardCultuurBebouwd\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"aardCultuurOnbebouwd\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"kadastraleAanduiding\": \"reprehenderit aliquip culpa exercitatio\",\n    \"kadastraleGrootte\": {\n     \"soortGrootte\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"perceelnummerVerschuiving\": {\n     \"deltax\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"deltay\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"adressen\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"zakelijkGerechtigdeIdentificaties\": [\n     \"elit consectetur tempor ex\",\n     \"aute\"\n    ],\n    \"privaatrechtelijkeBeperkingIdentificaties\": [\n     \"amet irure\",\n     \"sunt in velit\"\n    ],\n    \"hypotheekIdentificaties\": [\n     \"deserunt Duis enim\",\n     \"sed ex mollit\"\n    ],\n    \"beslagIdentificaties\": [\n     \"ex nulla quis aute ei\",\n     \"est enim sint laboris culpa\"\n    ],\n    \"isOvergegaanIn\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"isOntstaanUit\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"bijbehorendGrondperceelIdentificatie\": \"ad\",\n    \"stukIdentificaties\": [\n     \"elit id pariatur reprehenderit ad\",\n     \"non adipisicing proident laboris\"\n    ],\n    \"bijbehorendeAppartementsrechtIdentificaties\": [\n     \"anim ipsum et dolor\",\n     \"in deserunt voluptate sunt\"\n    ],\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"eu Excepteur sunt\"\n     },\n     \"zakelijkGerechtigden\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"privaatrechtelijkeBeperkingen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"hypotheken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isOntstaanUit\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isOvergegaanIn\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"beslagen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"adressen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"bijbehorendGrondperceel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"occaecat officia\"\n     },\n     \"bijbehorendeAppartementsrechten\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    },\n    \"_embedded\": {\n     \"zakelijkGerechtigden\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"privaatrechtelijkeBeperkingen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   },\n   {\n    \"identificatie\": \"quis esse qui ut\",\n    \"domein\": \"anim minim\",\n    \"begrenzingPerceel\": {\n     \"coordinates\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"type\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"perceelnummerRotatie\": -58806191.44948087,\n    \"plaatscoordinaten\": {\n     \"coordinates\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"type\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"koopsom\": {\n     \"koopsom\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"koopjaar\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"indicatieMetMeerObjectenVerkregen\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"toelichtingBewaarder\": \"cillum exercitation\",\n    \"type\": \"perceel\",\n    \"aardCultuurBebouwd\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"aardCultuurOnbebouwd\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"kadastraleAanduiding\": \"iru\",\n    \"kadastraleGrootte\": {\n     \"soortGrootte\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"perceelnummerVerschuiving\": {\n     \"deltax\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"deltay\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"adressen\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"zakelijkGerechtigdeIdentificaties\": [\n     \"pariatur sit consequat Duis do\",\n     \"fugiat incididunt\"\n    ],\n    \"privaatrechtelijkeBeperkingIdentificaties\": [\n     \"tempor\",\n     \"ea incididunt laboris\"\n    ],\n    \"hypotheekIdentificaties\": [\n     \"dolor in\",\n     \"deserunt\"\n    ],\n    \"beslagIdentificaties\": [\n     \"consectetur mollit\",\n     \"labore ad\"\n    ],\n    \"isOvergegaanIn\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"isOntstaanUit\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"bijbehorendGrondperceelIdentificatie\": \"est et amet\",\n    \"stukIdentificaties\": [\n     \"consequat sint ex\",\n     \"pariatur ullamco in\"\n    ],\n    \"bijbehorendeAppartementsrechtIdentificaties\": [\n     \"culp\",\n     \"cillum ipsum\"\n    ],\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"pariatur culpa nulla consectetur\"\n     },\n     \"zakelijkGerechtigden\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"privaatrechtelijkeBeperkingen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"hypotheken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isOntstaanUit\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isOvergegaanIn\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"beslagen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"adressen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"bijbehorendGrondperceel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"commodo Ut est\"\n     },\n     \"bijbehorendeAppartementsrechten\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    },\n    \"_embedded\": {\n     \"zakelijkGerechtigden\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"privaatrechtelijkeBeperkingen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   }\n  ]\n }\n}",
+                            "body": "{\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"ipsum culpa sed irure ut\"\n  }\n },\n \"_embedded\": {\n  \"kadastraalOnroerendeZaken\": [\n   {\n    \"identificatie\": \"magna dolor non\",\n    \"domein\": \"id in est dolore\",\n    \"begrenzingPerceel\": {\n     \"coordinates\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"type\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"perceelnummerRotatie\": -57133328.45005723,\n    \"plaatscoordinaten\": {\n     \"coordinates\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"type\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"koopsom\": {\n     \"koopsom\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"koopjaar\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"indicatieMetMeerObjectenVerkregen\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"toelichtingBewaarder\": \"aliqua enim esse\",\n    \"type\": \"perceel\",\n    \"aardCultuurBebouwd\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"aardCultuurOnbebouwd\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"kadastraleAanduiding\": \"ex commodo aute qui in\",\n    \"kadastraleGrootte\": {\n     \"soortGrootte\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"perceelnummerVerschuiving\": {\n     \"deltax\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"deltay\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"adressen\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"zakelijkGerechtigdeIdentificaties\": [\n     \"tempor nostrud\",\n     \"labore pariatur nulla voluptate\"\n    ],\n    \"privaatrechtelijkeBeperkingIdentificaties\": [\n     \"quis commodo do\",\n     \"c\"\n    ],\n    \"hypotheekIdentificaties\": [\n     \"dolor labore proident exerc\",\n     \"ut voluptate ea aliquip\"\n    ],\n    \"beslagIdentificaties\": [\n     \"sunt minim esse anim\",\n     \"fugiat magna non laboris\"\n    ],\n    \"isOvergegaanIn\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"isOntstaanUit\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"bijbehorendGrondperceelIdentificatie\": \"sint ut\",\n    \"bijbehorendeAppartementsrechtIdentificaties\": [\n     \"dolor voluptate ipsum\",\n     \"occaecat\"\n    ],\n    \"stukIdentificaties\": [\n     \"ad labore cillum\",\n     \"sed Excepteur\"\n    ],\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"velit id\"\n     },\n     \"zakelijkGerechtigden\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"privaatrechtelijkeBeperkingen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"hypotheken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isOntstaanUit\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isOvergegaanIn\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"beslagen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"adressen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"bijbehorendGrondperceel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"est\"\n     },\n     \"bijbehorendeAppartementsrechten\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    },\n    \"_embedded\": {\n     \"zakelijkGerechtigden\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"privaatrechtelijkeBeperkingen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   },\n   {\n    \"identificatie\": \"incididunt sed irure\",\n    \"domein\": \"laborum ut sit minim elit\",\n    \"begrenzingPerceel\": {\n     \"coordinates\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"type\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"perceelnummerRotatie\": -87589355.53060976,\n    \"plaatscoordinaten\": {\n     \"coordinates\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"type\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"koopsom\": {\n     \"koopsom\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"koopjaar\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"indicatieMetMeerObjectenVerkregen\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"toelichtingBewaarder\": \"ut ullamco ut esse occaecat\",\n    \"type\": \"appartementsrecht\",\n    \"aardCultuurBebouwd\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"aardCultuurOnbebouwd\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"kadastraleAanduiding\": \"quis velit re\",\n    \"kadastraleGrootte\": {\n     \"soortGrootte\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"perceelnummerVerschuiving\": {\n     \"deltax\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"deltay\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"adressen\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"zakelijkGerechtigdeIdentificaties\": [\n     \"consequat laborum ad sunt\",\n     \"in\"\n    ],\n    \"privaatrechtelijkeBeperkingIdentificaties\": [\n     \"in tempor minim dolor\",\n     \"eiusmod laboris ea\"\n    ],\n    \"hypotheekIdentificaties\": [\n     \"commodo eiusmod nostrud\",\n     \"exercitation Lorem\"\n    ],\n    \"beslagIdentificaties\": [\n     \"sed est sint su\",\n     \"aliqua\"\n    ],\n    \"isOvergegaanIn\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"isOntstaanUit\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"bijbehorendGrondperceelIdentificatie\": \"anim Excepteur\",\n    \"bijbehorendeAppartementsrechtIdentificaties\": [\n     \"minim nulla\",\n     \"voluptate laborum\"\n    ],\n    \"stukIdentificaties\": [\n     \"ipsum aute consequat\",\n     \"elit nulla ut\"\n    ],\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"enim et veniam sunt\"\n     },\n     \"zakelijkGerechtigden\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"privaatrechtelijkeBeperkingen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"hypotheken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isOntstaanUit\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isOvergegaanIn\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"beslagen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"adressen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"bijbehorendGrondperceel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"enim magna\"\n     },\n     \"bijbehorendeAppartementsrechten\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    },\n    \"_embedded\": {\n     \"zakelijkGerechtigden\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"privaatrechtelijkeBeperkingen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   }\n  ]\n }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d438a556-0ff1-469d-b5bb-56396786b92e",
+                            "id": "07377c0c-ff8d-44d1-a390-9b4446cf92e2",
                             "name": "Bad Request",
                             "originalRequest": {
                                 "url": {
@@ -276,7 +276,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "07482280-a829-4150-8611-4c1b4637daa8",
+                            "id": "0420ff0a-c850-488f-aa2b-a91e0e53eb6a",
                             "name": "Unauthorized",
                             "originalRequest": {
                                 "url": {
@@ -366,7 +366,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c40c5926-695f-4746-91a9-7fd05af62e86",
+                            "id": "aa039ce1-de80-4ab7-99e5-0a4c8ce16bbc",
                             "name": "Forbidden",
                             "originalRequest": {
                                 "url": {
@@ -456,7 +456,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "6a1d3ab1-2c6c-4111-bf3d-a61d8aacc68a",
+                            "id": "670e92ae-90b2-4b0f-9ad8-9c6c87af0cec",
                             "name": "Not Acceptable",
                             "originalRequest": {
                                 "url": {
@@ -546,7 +546,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "67db9b17-d347-4364-b202-94a5a562a35c",
+                            "id": "8c063852-9d2e-4f9f-b465-80305e0f72b6",
                             "name": "Gone",
                             "originalRequest": {
                                 "url": {
@@ -636,7 +636,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b7fbc3ff-958d-446b-91a7-f6218079e7c2",
+                            "id": "2f8eced9-8eb8-4258-a612-91cb25c3cd76",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -726,7 +726,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9c667e97-657b-4cbc-ae1a-2fd89b1578b4",
+                            "id": "51162960-9ba5-4c10-9cd5-3115db6890f3",
                             "name": "Service Unavailable",
                             "originalRequest": {
                                 "url": {
@@ -819,11 +819,11 @@
                     "event": []
                 },
                 {
-                    "id": "52d08e28-f206-4ee7-a67b-efa136a98e72",
+                    "id": "bf1e17fd-f620-467a-a92f-da0f5b902faa",
                     "name": "{kadastraalonroerendezaakidentificatie}",
                     "item": [
                         {
-                            "id": "94cafa20-6310-47dd-8b0e-80083b6d0629",
+                            "id": "68e03b91-5cbf-4836-b152-40c371bba29c",
                             "name": "Get Kadastraal Onroerende Zaak",
                             "request": {
                                 "name": "Get Kadastraal Onroerende Zaak",
@@ -872,7 +872,7 @@
                             },
                             "response": [
                                 {
-                                    "id": "9c7c5951-275c-4483-8ae1-64d81eb59c30",
+                                    "id": "42ca299d-63cb-4a3c-af12-3f639437c31b",
                                     "name": "Zoekactie geslaagd\n",
                                     "originalRequest": {
                                         "url": {
@@ -941,12 +941,12 @@
                                             "value": "application/hal+json"
                                         }
                                     ],
-                                    "body": "{\n \"identificatie\": \"fugiat in\",\n \"domein\": \"ad aliquip\",\n \"begrenzingPerceel\": {\n  \"coordinates\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"type\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"perceelnummerRotatie\": -59835542.916009076,\n \"plaatscoordinaten\": {\n  \"coordinates\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"type\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"koopsom\": {\n  \"koopsom\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"koopjaar\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"indicatieMetMeerObjectenVerkregen\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"toelichtingBewaarder\": \"qui exercitation dolore\",\n \"type\": \"perceel\",\n \"aardCultuurBebouwd\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"aardCultuurOnbebouwd\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"kadastraleAanduiding\": \"commodo ex in\",\n \"kadastraleGrootte\": {\n  \"soortGrootte\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"perceelnummerVerschuiving\": {\n  \"deltax\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"deltay\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"adressen\": [\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n ],\n \"zakelijkGerechtigdeIdentificaties\": [\n  \"reprehenderit sint labore\",\n  \"nisi\"\n ],\n \"privaatrechtelijkeBeperkingIdentificaties\": [\n  \"ullamco ut quis exercitation\",\n  \"qui id\"\n ],\n \"hypotheekIdentificaties\": [\n  \"ex Lorem nisi cupidatat\",\n  \"occaecat ipsum ullamco magna ex\"\n ],\n \"beslagIdentificaties\": [\n  \"eiusmod sed ullamco velit nostrud\",\n  \"non esse cupidatat aliqua\"\n ],\n \"isOvergegaanIn\": [\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n ],\n \"isOntstaanUit\": [\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n ],\n \"bijbehorendGrondperceelIdentificatie\": \"elit Ut mol\",\n \"stukIdentificaties\": [\n  \"in sint in incididunt\",\n  \"dolor Duis qui aute nos\"\n ],\n \"bijbehorendeAppartementsrechtIdentificaties\": [\n  \"elit ipsum eiusmod\",\n  \"dolor laborum in culpa\"\n ],\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"culpa ullamco laboris\"\n  },\n  \"zakelijkGerechtigden\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"privaatrechtelijkeBeperkingen\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"hypotheken\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"isOntstaanUit\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"isOvergegaanIn\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"beslagen\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"adressen\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"bijbehorendGrondperceel\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"culpa tempor ex velit amet\"\n  },\n  \"bijbehorendeAppartementsrechten\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"stukken\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ]\n },\n \"_embedded\": {\n  \"zakelijkGerechtigden\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"privaatrechtelijkeBeperkingen\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"stukken\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ]\n }\n}",
+                                    "body": "{\n \"identificatie\": \"sint laboris in\",\n \"domein\": \"do cillum sed\",\n \"begrenzingPerceel\": {\n  \"coordinates\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"type\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"perceelnummerRotatie\": -63345080.51183251,\n \"plaatscoordinaten\": {\n  \"coordinates\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"type\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"koopsom\": {\n  \"koopsom\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"koopjaar\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"indicatieMetMeerObjectenVerkregen\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"toelichtingBewaarder\": \"sunt incididunt deserunt\",\n \"type\": \"appartementsrecht\",\n \"aardCultuurBebouwd\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"aardCultuurOnbebouwd\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"kadastraleAanduiding\": \"ex aute\",\n \"kadastraleGrootte\": {\n  \"soortGrootte\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"perceelnummerVerschuiving\": {\n  \"deltax\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"deltay\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"adressen\": [\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n ],\n \"zakelijkGerechtigdeIdentificaties\": [\n  \"eiusmod consequat non ut\",\n  \"reprehenderit ad\"\n ],\n \"privaatrechtelijkeBeperkingIdentificaties\": [\n  \"in labore pariatur exercitation incididunt\",\n  \"occaecat est\"\n ],\n \"hypotheekIdentificaties\": [\n  \"magna labore quis\",\n  \"dolore non au\"\n ],\n \"beslagIdentificaties\": [\n  \"dolore sunt id ullamco\",\n  \"ut ex\"\n ],\n \"isOvergegaanIn\": [\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n ],\n \"isOntstaanUit\": [\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n ],\n \"bijbehorendGrondperceelIdentificatie\": \"Ut commodo\",\n \"bijbehorendeAppartementsrechtIdentificaties\": [\n  \"adipis\",\n  \"labore aliqua consectetur est\"\n ],\n \"stukIdentificaties\": [\n  \"aute ut\",\n  \"magna culpa Ut amet commodo\"\n ],\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"esse occaecat in tempor\"\n  },\n  \"zakelijkGerechtigden\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"privaatrechtelijkeBeperkingen\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"hypotheken\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"isOntstaanUit\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"isOvergegaanIn\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"beslagen\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"stukken\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"adressen\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"bijbehorendGrondperceel\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"cupidatat consectetur tempor\"\n  },\n  \"bijbehorendeAppartementsrechten\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ]\n },\n \"_embedded\": {\n  \"zakelijkGerechtigden\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"privaatrechtelijkeBeperkingen\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ]\n }\n}",
                                     "cookie": [],
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "1879627e-6558-40b4-9fa5-abddbbe96e8c",
+                                    "id": "0e03a063-9682-43e8-9213-1aee758feecc",
                                     "name": "Bad Request",
                                     "originalRequest": {
                                         "url": {
@@ -1010,7 +1010,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "a936f112-a50c-4c8c-91c7-cb01db57e8c1",
+                                    "id": "8d9abe48-246c-4de9-9e6a-b6795617ce95",
                                     "name": "Unauthorized",
                                     "originalRequest": {
                                         "url": {
@@ -1074,7 +1074,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "f222d162-349c-4cca-9b13-76228bd0f5b5",
+                                    "id": "e2f805fa-0bd9-42e6-a24b-aeec6660577d",
                                     "name": "Forbidden",
                                     "originalRequest": {
                                         "url": {
@@ -1138,7 +1138,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "344630f6-183d-4304-9894-528d09ada8ac",
+                                    "id": "8cebb6cd-db25-4197-ab4d-415c38ddad22",
                                     "name": "Not Found",
                                     "originalRequest": {
                                         "url": {
@@ -1202,7 +1202,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "7755b23b-3df2-4715-a3eb-3e965e2913b4",
+                                    "id": "41b9a8d3-7103-4a30-a01c-89ae84fc5b5f",
                                     "name": "Not Acceptable",
                                     "originalRequest": {
                                         "url": {
@@ -1266,7 +1266,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "26b8d93f-95fe-4ce8-8602-908c0d411970",
+                                    "id": "0a519e93-1fee-4a1e-aebe-c6d79a597e2f",
                                     "name": "Gone",
                                     "originalRequest": {
                                         "url": {
@@ -1330,7 +1330,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "82b55c6e-873d-4927-8ef7-5b9006e37db0",
+                                    "id": "a8c61d4d-97c2-4ac2-92b3-ec183e7bf32b",
                                     "name": "Internal Server Error",
                                     "originalRequest": {
                                         "url": {
@@ -1394,7 +1394,7 @@
                                     "_postman_previewlanguage": "json"
                                 },
                                 {
-                                    "id": "2c6921c4-bb44-4704-9887-ba96ee3ee787",
+                                    "id": "a5cc739f-0a80-4432-9008-383ac7c2d1aa",
                                     "name": "Service Unavailable",
                                     "originalRequest": {
                                         "url": {
@@ -1461,11 +1461,11 @@
                             "event": []
                         },
                         {
-                            "id": "412f277f-5051-45b8-8d45-d1844e30aa65",
+                            "id": "d2f2ffb6-ee3c-45e5-a389-95fe11b0393a",
                             "name": "zakelijkgerechtigden",
                             "item": [
                                 {
-                                    "id": "aa1a4988-a9e5-4845-9e9f-1bce540aae61",
+                                    "id": "37eda5ba-c3d3-49b4-93d2-cbafbce9ffeb",
                                     "name": "Get Zakelijk Gerechtigden",
                                     "request": {
                                         "name": "Get Zakelijk Gerechtigden",
@@ -1515,7 +1515,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "6afeff3f-af35-4a14-ae38-ea7e5a5e34b7",
+                                            "id": "bbccbf59-7aa7-4686-b048-939dd0dc15e3",
                                             "name": "Zoekactie geslaagd\n",
                                             "originalRequest": {
                                                 "url": {
@@ -1585,12 +1585,12 @@
                                                     "value": "application/hal+json"
                                                 }
                                             ],
-                                            "body": "{\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"sunt deserunt velit ad\"\n  }\n },\n \"_embedded\": {\n  \"zakelijkGerechtigden\": [\n   {\n    \"identificatie\": \"fu\",\n    \"type\": \"<string>\",\n    \"aanvangsdatum\": \"2017-03-31\",\n    \"erfpachtCanon\": {\n     \"soortErfpachtCanon\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"jaarlijksBedrag\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"betrefMeerOnroerendeZaken\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"einddatumAfkoop\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"indicatieOudeOnroerendeZaakBetrokken\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"isGebaseerdOpStukdeelIdentificatie\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"isVermeldInStukdeelIdentificaties\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"tenaamstelling\": {\n     \"aandeel\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"burgerlijkeStaatTenTijdeVanVerkrijging\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"verkregenNamensSamenwerkingsverband\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"aantekeningen\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"gezamenlijkAandeel\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"betrokkenPartner\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"betrokkenSamenwerkingsverband\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"betrokkenGorzenEnAanwassen\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"isGebaseerdOpStukdeelIdentificatie\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"isVermeldInStukdeelIdentificaties\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"persoon\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"stukIdentificaties\": [\n     \"enim\",\n     \"sit Excepteur\"\n    ],\n    \"isGebaseerdOpStukdeelIdentificatie\": \"nulla qui\",\n    \"isVermeldInStukdeelIdentificaties\": [\n     \"Excepteur Lorem laboris\",\n     \"anim ut\"\n    ],\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"sint\"\n     },\n     \"persoon\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"cillum in quis id dolor\"\n     },\n     \"betrokkenPartner\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"commodo reprehenderit incididunt\"\n     },\n     \"betrokkenSamenwerkingsverband\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"reprehenderit dolore c\"\n     },\n     \"betrokkenGorzenEnAanwassen\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"Excepteur velit nisi reprehenderit sed\"\n     },\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isGebaseerdOpStukdeel\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isVermeldInStukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   },\n   {\n    \"identificatie\": \"Lorem pariatur sit\",\n    \"type\": \"<string>\",\n    \"aanvangsdatum\": \"1984-09-30\",\n    \"erfpachtCanon\": {\n     \"soortErfpachtCanon\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"jaarlijksBedrag\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"betrefMeerOnroerendeZaken\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"einddatumAfkoop\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"indicatieOudeOnroerendeZaakBetrokken\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"isGebaseerdOpStukdeelIdentificatie\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"isVermeldInStukdeelIdentificaties\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"tenaamstelling\": {\n     \"aandeel\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"burgerlijkeStaatTenTijdeVanVerkrijging\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"verkregenNamensSamenwerkingsverband\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"aantekeningen\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"gezamenlijkAandeel\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"betrokkenPartner\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"betrokkenSamenwerkingsverband\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"betrokkenGorzenEnAanwassen\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"isGebaseerdOpStukdeelIdentificatie\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"isVermeldInStukdeelIdentificaties\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"persoon\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"stukIdentificaties\": [\n     \"Lorem a\",\n     \"est occaecat\"\n    ],\n    \"isGebaseerdOpStukdeelIdentificatie\": \"ut aliquip\",\n    \"isVermeldInStukdeelIdentificaties\": [\n     \"irur\",\n     \"elit\"\n    ],\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"consectetur in enim tempor ut\"\n     },\n     \"persoon\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"enim culp\"\n     },\n     \"betrokkenPartner\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"dolore\"\n     },\n     \"betrokkenSamenwerkingsverband\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"adipisicing amet commodo deserunt\"\n     },\n     \"betrokkenGorzenEnAanwassen\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"eiusmod magna\"\n     },\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isGebaseerdOpStukdeel\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isVermeldInStukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   }\n  ],\n  \"stukken\": [\n   {\n    \"identificatie\": \"irure occaecat proident Ut\",\n    \"stukType\": \"Aangebodenstuk\",\n    \"domein\": \"elit et\",\n    \"toelichtingBewaarder\": \"irure adipisicing\",\n    \"stukdeelIdentificaties\": [\n     \"in ad ut\",\n     \"amet anim\"\n    ],\n    \"bewaardersVerklaring\": \"dolor nostrud dolore\",\n    \"tekeningIngeschreven\": true,\n    \"tijdstipAanbieding\": \"1973-11-28T09:55:19.126Z\",\n    \"tijdstipOndertekening\": \"1997-05-12T22:57:46.892Z\",\n    \"aard\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"status\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"equivalentieVerklaarder\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"kadasterverzoeken\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"oorspronkelijkStukIdentificatie\": \"esse\",\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"consequ\"\n     },\n     \"stukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"oorspronkelijkStuk\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"pariatur et\"\n     }\n    }\n   },\n   {\n    \"identificatie\": \"mollit incididunt voluptate\",\n    \"stukType\": \"Aangebodenstuk\",\n    \"domein\": \"non eu qui\",\n    \"toelichtingBewaarder\": \"minim do\",\n    \"stukdeelIdentificaties\": [\n     \"sit adipisicing\",\n     \"Excepteur ad\"\n    ],\n    \"bewaardersVerklaring\": \"minim enim in\",\n    \"tekeningIngeschreven\": true,\n    \"tijdstipAanbieding\": \"1950-10-24T09:16:02.882Z\",\n    \"tijdstipOndertekening\": \"2015-09-21T19:22:05.861Z\",\n    \"aard\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"status\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"equivalentieVerklaarder\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"kadasterverzoeken\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"oorspronkelijkStukIdentificatie\": \"Excepteur elit\",\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"aliqua aute\"\n     },\n     \"stukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"oorspronkelijkStuk\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"proident reprehenderit quis esse culpa\"\n     }\n    }\n   }\n  ],\n  \"stukdelen\": [\n   {\n    \"identificatie\": \"dolore\",\n    \"domein\": \"nostrud nulla culpa eu\",\n    \"aard\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"bedragTransactiesomLevering\": {\n     \"som\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"valuta\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"omschrijvingKadastraleObjecten\": \"laboris\",\n    \"omschrijvingTopografischeMutatie\": \"sed sit\",\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"occaecat pariatur reprehenderit\"\n     },\n     \"stuk\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"Lorem magna\"\n     },\n     \"kadastraalOnroerendeZaken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   },\n   {\n    \"identificatie\": \"ex\",\n    \"domein\": \"adipisicing eu amet voluptate Lorem\",\n    \"aard\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"bedragTransactiesomLevering\": {\n     \"som\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"valuta\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"omschrijvingKadastraleObjecten\": \"fugiat elit cillum ea\",\n    \"omschrijvingTopografischeMutatie\": \"minim eiusmod labore\",\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"ex amet\"\n     },\n     \"stuk\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"cupidatat sunt\"\n     },\n     \"kadastraalOnroerendeZaken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   }\n  ]\n }\n}",
+                                            "body": "{\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"magna consequat\"\n  }\n },\n \"_embedded\": {\n  \"zakelijkGerechtigden\": [\n   {\n    \"identificatie\": \"anim amet\",\n    \"type\": \"<string>\",\n    \"aanvangsdatum\": \"2005-12-06\",\n    \"erfpachtCanon\": {\n     \"soortErfpachtCanon\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"jaarlijksBedrag\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"betrefMeerOnroerendeZaken\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"einddatumAfkoop\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"indicatieOudeOnroerendeZaakBetrokken\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"isGebaseerdOpStukdeelIdentificatie\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"isVermeldInStukdeelIdentificaties\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"tenaamstelling\": {\n     \"aandeel\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"burgerlijkeStaatTenTijdeVanVerkrijging\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"verkregenNamensSamenwerkingsverband\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"aantekeningen\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"gezamenlijkAandeel\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"betrokkenPartner\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"betrokkenSamenwerkingsverband\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"betrokkenGorzenEnAanwassen\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"isGebaseerdOpStukdeelIdentificatie\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"isVermeldInStukdeelIdentificaties\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"persoon\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"stukIdentificaties\": [\n     \"elit nisi do\",\n     \"occaecat en\"\n    ],\n    \"isGebaseerdOpStukdeelIdentificatie\": \"enim cupidatat occaecat\",\n    \"isVermeldInStukdeelIdentificaties\": [\n     \"reprehenderit aliquip dolore\",\n     \"nisi in cillum anim\"\n    ],\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"incididunt Ut\"\n     },\n     \"persoon\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"dolore cupidatat ex esse\"\n     },\n     \"betrokkenPartner\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"deserunt irure quis\"\n     },\n     \"betrokkenSamenwerkingsverband\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"exercitation commodo non\"\n     },\n     \"betrokkenGorzenEnAanwassen\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"sed consequat magna\"\n     },\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isGebaseerdOpStukdeel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"eu Lorem\"\n     },\n     \"isVermeldInStukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   },\n   {\n    \"identificatie\": \"sed laborum consequat amet\",\n    \"type\": \"<string>\",\n    \"aanvangsdatum\": \"1977-02-18\",\n    \"erfpachtCanon\": {\n     \"soortErfpachtCanon\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"jaarlijksBedrag\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"betrefMeerOnroerendeZaken\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"einddatumAfkoop\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"indicatieOudeOnroerendeZaakBetrokken\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"isGebaseerdOpStukdeelIdentificatie\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"isVermeldInStukdeelIdentificaties\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"tenaamstelling\": {\n     \"aandeel\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"burgerlijkeStaatTenTijdeVanVerkrijging\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"verkregenNamensSamenwerkingsverband\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"aantekeningen\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"gezamenlijkAandeel\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"betrokkenPartner\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"betrokkenSamenwerkingsverband\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"betrokkenGorzenEnAanwassen\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"isGebaseerdOpStukdeelIdentificatie\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"isVermeldInStukdeelIdentificaties\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"persoon\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"stukIdentificaties\": [\n     \"esse magna\",\n     \"esse\"\n    ],\n    \"isGebaseerdOpStukdeelIdentificatie\": \"irure enim\",\n    \"isVermeldInStukdeelIdentificaties\": [\n     \"eiusmod do fugiat exercitation elit\",\n     \"Duis sint nostrud in\"\n    ],\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"incididunt dolor\"\n     },\n     \"persoon\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"deserunt\"\n     },\n     \"betrokkenPartner\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"nisi voluptate\"\n     },\n     \"betrokkenSamenwerkingsverband\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"nulla\"\n     },\n     \"betrokkenGorzenEnAanwassen\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"minim ut proident esse\"\n     },\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isGebaseerdOpStukdeel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"in sit\"\n     },\n     \"isVermeldInStukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   }\n  ]\n }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "1909329f-6c6f-4bd0-83b0-5cca7883d026",
+                                            "id": "b8e53f81-7d02-4290-b465-7de21ca7496e",
                                             "name": "Bad Request",
                                             "originalRequest": {
                                                 "url": {
@@ -1655,7 +1655,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "137574bd-f9ce-4f9e-8f0c-3f0d683aeb1e",
+                                            "id": "9fec1e62-4f8e-4608-90d8-7af67ab6c6a4",
                                             "name": "Unauthorized",
                                             "originalRequest": {
                                                 "url": {
@@ -1720,7 +1720,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "1538fe74-5f33-48ea-958c-2a3a594d18dc",
+                                            "id": "8d5ab453-2912-4d8a-9fd1-32f358bc3330",
                                             "name": "Forbidden",
                                             "originalRequest": {
                                                 "url": {
@@ -1785,7 +1785,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "986fac02-1473-476f-9d89-d843ce710185",
+                                            "id": "805e8cbf-7336-467f-8de4-034a6f191446",
                                             "name": "Not Found",
                                             "originalRequest": {
                                                 "url": {
@@ -1850,7 +1850,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "44f66f91-b3ef-4c99-b468-68c86a42396f",
+                                            "id": "b4d34023-01ac-41b2-acc3-626a013ecea7",
                                             "name": "Not Acceptable",
                                             "originalRequest": {
                                                 "url": {
@@ -1915,7 +1915,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "ef8f1149-71bc-4c91-bbf3-fcd1cc2e6fd0",
+                                            "id": "7eb9cd11-7f68-41cf-983b-ebbad741883c",
                                             "name": "Gone",
                                             "originalRequest": {
                                                 "url": {
@@ -1980,7 +1980,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "c00fe3ab-3848-4f66-b2a2-9ba6d97a51df",
+                                            "id": "612d84f4-8726-4af0-b15e-4ef1ff7d6107",
                                             "name": "Internal Server Error",
                                             "originalRequest": {
                                                 "url": {
@@ -2045,7 +2045,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "224da310-567f-4b26-8495-1485761f5000",
+                                            "id": "819562f9-55ed-48fc-84d7-1f7a44ef2e0d",
                                             "name": "Service Unavailable",
                                             "originalRequest": {
                                                 "url": {
@@ -2113,7 +2113,7 @@
                                     "event": []
                                 },
                                 {
-                                    "id": "f37d4cbe-00a8-401b-a41b-a7701785e1a5",
+                                    "id": "1ef07d62-81e2-4cb7-909d-2e928443b0c7",
                                     "name": "Get Zakelijk Gerechtigde",
                                     "request": {
                                         "name": "Get Zakelijk Gerechtigde",
@@ -2165,7 +2165,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "21f46a07-5ff5-44f0-8993-36c11d0142f8",
+                                            "id": "e0d11f30-0458-4ff5-85f3-9f555feba7a6",
                                             "name": "Zoekactie geslaagd\n",
                                             "originalRequest": {
                                                 "url": {
@@ -2236,12 +2236,12 @@
                                                     "value": "application/hal+json"
                                                 }
                                             ],
-                                            "body": "{\n \"identificatie\": \"quis magna\",\n \"type\": \"<string>\",\n \"aanvangsdatum\": \"2012-09-18\",\n \"erfpachtCanon\": {\n  \"soortErfpachtCanon\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"jaarlijksBedrag\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"betrefMeerOnroerendeZaken\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"einddatumAfkoop\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"indicatieOudeOnroerendeZaakBetrokken\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"isGebaseerdOpStukdeelIdentificatie\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"isVermeldInStukdeelIdentificaties\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"tenaamstelling\": {\n  \"aandeel\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"burgerlijkeStaatTenTijdeVanVerkrijging\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"verkregenNamensSamenwerkingsverband\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"aantekeningen\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"gezamenlijkAandeel\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"betrokkenPartner\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"betrokkenSamenwerkingsverband\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"betrokkenGorzenEnAanwassen\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"isGebaseerdOpStukdeelIdentificatie\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"isVermeldInStukdeelIdentificaties\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"persoon\": {\n  \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n },\n \"stukIdentificaties\": [\n  \"sit exercitatio\",\n  \"laborum amet Ut veniam\"\n ],\n \"isGebaseerdOpStukdeelIdentificatie\": \"deserunt velit aliqua anim Ut\",\n \"isVermeldInStukdeelIdentificaties\": [\n  \"fugiat consequat\",\n  \"magna voluptate\"\n ],\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"reprehenderit\"\n  },\n  \"persoon\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"labore sed nostrud et\"\n  },\n  \"betrokkenPartner\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"irure Duis voluptate incididunt non\"\n  },\n  \"betrokkenSamenwerkingsverband\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"aute do velit occaecat\"\n  },\n  \"betrokkenGorzenEnAanwassen\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"non et\"\n  },\n  \"stukken\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"isGebaseerdOpStukdeel\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"isVermeldInStukdelen\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ]\n }\n}",
+                                            "body": "{\n \"identificatie\": \"sunt reprehenderit sint esse proident\",\n \"type\": \"<string>\",\n \"aanvangsdatum\": \"1994-11-25\",\n \"erfpachtCanon\": {\n  \"soortErfpachtCanon\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"jaarlijksBedrag\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"betrefMeerOnroerendeZaken\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"einddatumAfkoop\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"indicatieOudeOnroerendeZaakBetrokken\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"isGebaseerdOpStukdeelIdentificatie\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"isVermeldInStukdeelIdentificaties\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"tenaamstelling\": {\n  \"aandeel\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"burgerlijkeStaatTenTijdeVanVerkrijging\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"verkregenNamensSamenwerkingsverband\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"aantekeningen\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"gezamenlijkAandeel\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"betrokkenPartner\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"betrokkenSamenwerkingsverband\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"betrokkenGorzenEnAanwassen\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"isGebaseerdOpStukdeelIdentificatie\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"isVermeldInStukdeelIdentificaties\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"persoon\": {\n  \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n },\n \"stukIdentificaties\": [\n  \"non\",\n  \"anim minim Excepteur\"\n ],\n \"isGebaseerdOpStukdeelIdentificatie\": \"aliquip nulla irure\",\n \"isVermeldInStukdeelIdentificaties\": [\n  \"Lorem do magna labore in\",\n  \"ad labore\"\n ],\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"sed est\"\n  },\n  \"persoon\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"qui commodo voluptate elit\"\n  },\n  \"betrokkenPartner\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"laboris do commodo\"\n  },\n  \"betrokkenSamenwerkingsverband\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"nulla ad irure\"\n  },\n  \"betrokkenGorzenEnAanwassen\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"amet nisi veniam pariatur\"\n  },\n  \"stukken\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"isGebaseerdOpStukdeel\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"amet fugiat\"\n  },\n  \"isVermeldInStukdelen\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ]\n }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "eb789672-2125-4d0b-8a88-92a9ab000c78",
+                                            "id": "16aa6c28-9b53-4fd8-8483-14c6f27023aa",
                                             "name": "Bad Request",
                                             "originalRequest": {
                                                 "url": {
@@ -2307,7 +2307,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "bd4b1570-654a-4cd3-91e3-443b7b348798",
+                                            "id": "78eccad4-ba57-4bc3-97d5-8ab24b0f8283",
                                             "name": "Unauthorized",
                                             "originalRequest": {
                                                 "url": {
@@ -2373,7 +2373,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "1021e868-96a3-4b78-8916-88b50d130eee",
+                                            "id": "cac7fd35-051f-476f-86ee-5c48bb66447a",
                                             "name": "Forbidden",
                                             "originalRequest": {
                                                 "url": {
@@ -2439,7 +2439,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "85d7b951-9d36-44ad-b043-7fd7802b35af",
+                                            "id": "124c2256-19c4-4170-a2f7-f82ec228467b",
                                             "name": "Not Found",
                                             "originalRequest": {
                                                 "url": {
@@ -2505,7 +2505,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "fdb4f486-54bb-4d94-8189-45f78eaf2247",
+                                            "id": "6732d535-a72b-4650-817a-81441d0a477d",
                                             "name": "Not Acceptable",
                                             "originalRequest": {
                                                 "url": {
@@ -2571,7 +2571,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "f06d3fff-9280-41f2-9ef6-4aefb70a8424",
+                                            "id": "edc3c2c8-32e5-4a17-94c5-ba2bd859f526",
                                             "name": "Gone",
                                             "originalRequest": {
                                                 "url": {
@@ -2637,7 +2637,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "e1a29923-803d-4af3-821a-4a183dff9b8e",
+                                            "id": "9c0dd921-1b40-4051-8df4-b2411c71f1ed",
                                             "name": "Internal Server Error",
                                             "originalRequest": {
                                                 "url": {
@@ -2703,7 +2703,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "5b149c65-669f-43b2-b9f3-2de1e5076fc7",
+                                            "id": "6c223bf5-9c7d-479a-8139-39cbb062f6a8",
                                             "name": "Service Unavailable",
                                             "originalRequest": {
                                                 "url": {
@@ -2775,11 +2775,11 @@
                             "event": []
                         },
                         {
-                            "id": "13a4ddfd-8df4-45a3-a875-30009fb5533e",
+                            "id": "d70f5b78-e460-4eaf-99b5-dd97b627cbca",
                             "name": "hypotheken",
                             "item": [
                                 {
-                                    "id": "44314acf-85d6-4f5a-b9eb-da769d9a88cf",
+                                    "id": "1204f49c-e5db-4e71-8d95-5da40d5ab10b",
                                     "name": "Get Hypotheken Kadastraal Onroerende Zaak",
                                     "request": {
                                         "name": "Get Hypotheken Kadastraal Onroerende Zaak",
@@ -2824,7 +2824,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "ab40f402-9d4f-4cef-b494-19c7eee58169",
+                                            "id": "15ab2bba-595f-4abb-9c7d-b0504bfcbda4",
                                             "name": "Zoekactie geslaagd\n",
                                             "originalRequest": {
                                                 "url": {
@@ -2890,12 +2890,12 @@
                                                     "value": "application/hal+json"
                                                 }
                                             ],
-                                            "body": "{\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"magna in qui\"\n  }\n },\n \"_embedded\": {\n  \"hypotheken\": [\n   {\n    \"identificatie\": \"in consequat aliqua\",\n    \"domein\": \"voluptate aliqua tempor aute nisi\",\n    \"aandeelInBetrokkenRecht\": {\n     \"noemer\": 2,\n     \"teller\": 1\n    },\n    \"gedeeltelijkeBezwaringOudObject\": false,\n    \"omschrijvingBetrokkenRecht\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"toelichtingBewaarder\": \"cupidatat\",\n    \"betreftGedeelteVanPerceel\": false,\n    \"aantekeningen\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"hypotheekhouders\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"bedragZekerheidsstelling\": {\n     \"som\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"valuta\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"stukIdentificaties\": [\n     \"dolore Ut aute\",\n     \"velit quis aliquip labore irure\"\n    ],\n    \"omschrijvingGekozenWoonplaats\": \"exercitation Duis\",\n    \"isGebaseerdOpStukdeelIdentificatie\": \"laborum veniam in reprehenderit sed\",\n    \"isVermeldInStukdeelIdentificaties\": [\n     \"ea pariatur\",\n     \"nisi velit ad aliquip\"\n    ],\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"deserunt Lorem\"\n     },\n     \"hypotheekhouders\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isGebaseerdOpStukdeel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"esse in sed\"\n     },\n     \"isVermeldInStukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   },\n   {\n    \"identificatie\": \"non\",\n    \"domein\": \"velit eiusmod qui deserunt\",\n    \"aandeelInBetrokkenRecht\": {\n     \"noemer\": 2,\n     \"teller\": 1\n    },\n    \"gedeeltelijkeBezwaringOudObject\": false,\n    \"omschrijvingBetrokkenRecht\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"toelichtingBewaarder\": \"incididunt Excepteur\",\n    \"betreftGedeelteVanPerceel\": false,\n    \"aantekeningen\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"hypotheekhouders\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"bedragZekerheidsstelling\": {\n     \"som\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"valuta\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"stukIdentificaties\": [\n     \"\",\n     \"ut Excepteur ipsum\"\n    ],\n    \"omschrijvingGekozenWoonplaats\": \"ad minim\",\n    \"isGebaseerdOpStukdeelIdentificatie\": \"reprehenderit proident\",\n    \"isVermeldInStukdeelIdentificaties\": [\n     \"cillum dolor adipisicing culpa velit\",\n     \"velit Ut dolore nulla\"\n    ],\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"officia irure occ\"\n     },\n     \"hypotheekhouders\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isGebaseerdOpStukdeel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"consectetur exercitation irure dolor in\"\n     },\n     \"isVermeldInStukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   }\n  ]\n }\n}",
+                                            "body": "{\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"esse est\"\n  }\n },\n \"_embedded\": {\n  \"hypotheken\": [\n   {\n    \"identificatie\": \"dolore reprehenderit in\",\n    \"domein\": \"amet eiusmod enim et anim\",\n    \"aandeelInBetrokkenRecht\": {\n     \"noemer\": 2,\n     \"teller\": 1\n    },\n    \"gedeeltelijkeBezwaringOudObject\": false,\n    \"omschrijvingBetrokkenRecht\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"toelichtingBewaarder\": \"sunt consectetur\",\n    \"betreftGedeelteVanPerceel\": true,\n    \"aantekeningen\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"hypotheekhouders\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"bedragZekerheidsstelling\": {\n     \"som\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"valuta\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"stukIdentificaties\": [\n     \"nisi aliquip id nostrud minim\",\n     \"in velit\"\n    ],\n    \"omschrijvingGekozenWoonplaats\": \"adipisicing aliquip\",\n    \"isGebaseerdOpStukdeelIdentificatie\": \"proident occaecat dolore enim\",\n    \"isVermeldInStukdeelIdentificaties\": [\n     \"aliqua nisi tempor\",\n     \"qui aute\"\n    ],\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"reprehenderit do tempor\"\n     },\n     \"hypotheekhouders\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isGebaseerdOpStukdeel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"eu anim consectetur\"\n     },\n     \"isVermeldInStukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   },\n   {\n    \"identificatie\": \"laborum anim com\",\n    \"domein\": \"in ut minim\",\n    \"aandeelInBetrokkenRecht\": {\n     \"noemer\": 2,\n     \"teller\": 1\n    },\n    \"gedeeltelijkeBezwaringOudObject\": true,\n    \"omschrijvingBetrokkenRecht\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"toelichtingBewaarder\": \"aliqua laboris Ut est\",\n    \"betreftGedeelteVanPerceel\": false,\n    \"aantekeningen\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"hypotheekhouders\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"bedragZekerheidsstelling\": {\n     \"som\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"valuta\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"stukIdentificaties\": [\n     \"cupidatat ut do exercitation\",\n     \"anim aute voluptate nisi nostrud\"\n    ],\n    \"omschrijvingGekozenWoonplaats\": \"mollit ut proident\",\n    \"isGebaseerdOpStukdeelIdentificatie\": \"est id dolor proident\",\n    \"isVermeldInStukdeelIdentificaties\": [\n     \"esse ut sit\",\n     \"sunt \"\n    ],\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"minim Ut do ad\"\n     },\n     \"hypotheekhouders\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isGebaseerdOpStukdeel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"occaecat quis voluptate elit nisi\"\n     },\n     \"isVermeldInStukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   }\n  ]\n }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "70f3fe45-8d27-4ffa-811a-89d239c9e00d",
+                                            "id": "5bbdfe7f-d316-466d-a101-41c8336b5002",
                                             "name": "Bad Request",
                                             "originalRequest": {
                                                 "url": {
@@ -2956,7 +2956,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "593ee8cd-d26f-4a2a-af52-f996b6033565",
+                                            "id": "23832cf2-08ca-4830-8b9c-03594f634079",
                                             "name": "Unauthorized",
                                             "originalRequest": {
                                                 "url": {
@@ -3017,7 +3017,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "d0698c9b-aa9c-46b9-b125-80abab8f6a23",
+                                            "id": "56dfcbb1-56ad-48bf-8646-28fe68e36ea3",
                                             "name": "Forbidden",
                                             "originalRequest": {
                                                 "url": {
@@ -3078,7 +3078,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "7ff45ee8-bc8d-4863-ad6a-c23c5db85d1d",
+                                            "id": "35d65fb4-1f1c-4252-82ae-8fb57da83bae",
                                             "name": "Not Found",
                                             "originalRequest": {
                                                 "url": {
@@ -3139,7 +3139,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "a49d3b01-facd-422b-bb53-f2fb03b8c253",
+                                            "id": "4bdc749f-e519-4232-bf35-d51051ff6fa1",
                                             "name": "Not Acceptable",
                                             "originalRequest": {
                                                 "url": {
@@ -3200,7 +3200,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "5bf475b2-5429-4d1a-a43d-8dd7e51b31e4",
+                                            "id": "19e0aa00-eceb-41ec-b1e2-fa153c9634ec",
                                             "name": "Gone",
                                             "originalRequest": {
                                                 "url": {
@@ -3261,7 +3261,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "05eeec09-501b-47f9-a320-2bbd07ce53e2",
+                                            "id": "49a7ebae-9508-49e8-a301-4cadb81406da",
                                             "name": "Internal Server Error",
                                             "originalRequest": {
                                                 "url": {
@@ -3322,7 +3322,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "9eafc20e-4c70-4d19-9a11-e69372d7e4ca",
+                                            "id": "c1c2fbff-0024-486a-8e10-221a70748626",
                                             "name": "Service Unavailable",
                                             "originalRequest": {
                                                 "url": {
@@ -3386,7 +3386,7 @@
                                     "event": []
                                 },
                                 {
-                                    "id": "ad3597fd-e348-4c5f-a2b5-ff5e3358ed35",
+                                    "id": "a5d69282-fdb1-4835-8dc7-ab397be18d6b",
                                     "name": "Get Hypotheek",
                                     "request": {
                                         "name": "Get Hypotheek",
@@ -3438,7 +3438,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "a9891bc1-85de-4526-957b-ba717ef509c6",
+                                            "id": "57d10fdc-3242-448a-b76f-9841c85cdce2",
                                             "name": "Raadplegen geslaagd\n",
                                             "originalRequest": {
                                                 "url": {
@@ -3509,12 +3509,12 @@
                                                     "value": "application/hal+json"
                                                 }
                                             ],
-                                            "body": "{\n \"identificatie\": \"id eiu\",\n \"domein\": \"cupid\",\n \"aandeelInBetrokkenRecht\": {\n  \"noemer\": 2,\n  \"teller\": 1\n },\n \"gedeeltelijkeBezwaringOudObject\": false,\n \"omschrijvingBetrokkenRecht\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"toelichtingBewaarder\": \"Excepteur non enim dolore\",\n \"betreftGedeelteVanPerceel\": false,\n \"aantekeningen\": [\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n ],\n \"hypotheekhouders\": [\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n ],\n \"bedragZekerheidsstelling\": {\n  \"som\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"valuta\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"stukIdentificaties\": [\n  \"magna quis irure non\",\n  \"sunt in\"\n ],\n \"omschrijvingGekozenWoonplaats\": \"proident minim anim in\",\n \"isGebaseerdOpStukdeelIdentificatie\": \"veni\",\n \"isVermeldInStukdeelIdentificaties\": [\n  \"laborum magna nulla ad\",\n  \"aute sed incididunt\"\n ],\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"occaecat aute ut\"\n  },\n  \"hypotheekhouders\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"stukken\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"isGebaseerdOpStukdeel\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"dolor ipsum\"\n  },\n  \"isVermeldInStukdelen\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ]\n }\n}",
+                                            "body": "{\n \"identificatie\": \"in\",\n \"domein\": \"minim\",\n \"aandeelInBetrokkenRecht\": {\n  \"noemer\": 2,\n  \"teller\": 1\n },\n \"gedeeltelijkeBezwaringOudObject\": false,\n \"omschrijvingBetrokkenRecht\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"toelichtingBewaarder\": \"non Duis laboris\",\n \"betreftGedeelteVanPerceel\": false,\n \"aantekeningen\": [\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n ],\n \"hypotheekhouders\": [\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n ],\n \"bedragZekerheidsstelling\": {\n  \"som\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"valuta\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"stukIdentificaties\": [\n  \"enim ut ipsum irure\",\n  \"aliqua consectetur in\"\n ],\n \"omschrijvingGekozenWoonplaats\": \"Ut\",\n \"isGebaseerdOpStukdeelIdentificatie\": \"sunt dolor occaecat culpa\",\n \"isVermeldInStukdeelIdentificaties\": [\n  \"dolor consectetur dolore exercitation\",\n  \"anim reprehenderit elit ex dolor\"\n ],\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"nulla aute labore sunt\"\n  },\n  \"hypotheekhouders\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"stukken\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"isGebaseerdOpStukdeel\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"amet sit Duis commodo deserunt\"\n  },\n  \"isVermeldInStukdelen\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ]\n }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "ac3a21a1-1983-4f47-9b03-0aa68f8d6919",
+                                            "id": "c72e80f6-1f0b-429f-bf8a-bfd22c1211b3",
                                             "name": "Bad Request",
                                             "originalRequest": {
                                                 "url": {
@@ -3580,7 +3580,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "b52e8446-5201-497f-bdf6-d513241fa029",
+                                            "id": "884b21ec-96e8-4772-a72d-206692657e1a",
                                             "name": "Unauthorized",
                                             "originalRequest": {
                                                 "url": {
@@ -3646,7 +3646,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "5ad45eba-3a9f-445d-9c15-ad6e0cc41fdd",
+                                            "id": "31f67110-0c8e-4008-b599-fcf6371ff580",
                                             "name": "Forbidden",
                                             "originalRequest": {
                                                 "url": {
@@ -3712,7 +3712,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "de0985c2-dc49-413f-85ec-a7e0019a13a4",
+                                            "id": "1f7f412b-a3a3-4290-a68e-85e5ce112208",
                                             "name": "Not Found",
                                             "originalRequest": {
                                                 "url": {
@@ -3778,7 +3778,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "0e3a6422-0519-40d0-9bad-0b0712abc47d",
+                                            "id": "6260bc43-55e8-4320-a38a-a4e678b27291",
                                             "name": "Not Acceptable",
                                             "originalRequest": {
                                                 "url": {
@@ -3844,7 +3844,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "5d06a20d-5049-4776-b6ed-e50888a33caf",
+                                            "id": "4417dbbd-c07f-410a-b8fd-f39689f492fd",
                                             "name": "Gone",
                                             "originalRequest": {
                                                 "url": {
@@ -3910,7 +3910,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "9a0b7071-f878-40ed-9827-4ec2d5a5ae33",
+                                            "id": "a2c1bd28-8bb8-445f-8bfe-ffb479b8e83a",
                                             "name": "Precondition failed",
                                             "originalRequest": {
                                                 "url": {
@@ -3976,7 +3976,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "1906c237-df42-48c2-963a-8f3dcf1129af",
+                                            "id": "c55ef443-29ee-4baf-ab77-baeb9d9805b1",
                                             "name": "Unsupported Media Type",
                                             "originalRequest": {
                                                 "url": {
@@ -4042,7 +4042,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "2ebaf8d4-06bb-44c3-aacf-03bda040fafc",
+                                            "id": "99801f39-abba-4392-b697-9c9475fa308b",
                                             "name": "Internal Server Error",
                                             "originalRequest": {
                                                 "url": {
@@ -4108,7 +4108,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "6c1f80e8-e529-4a44-a6e7-ddb711502f64",
+                                            "id": "a398242f-c2ae-4dbb-941c-6fbe308fad4e",
                                             "name": "Service Unavailable",
                                             "originalRequest": {
                                                 "url": {
@@ -4180,11 +4180,11 @@
                             "event": []
                         },
                         {
-                            "id": "804792eb-8c01-46bd-9ca6-15aabef289bf",
+                            "id": "d08782fc-3ce5-4bf5-96cf-5bd6dd21db0b",
                             "name": "beslagen",
                             "item": [
                                 {
-                                    "id": "5fa0344c-91b4-4a57-ba4a-61663401a713",
+                                    "id": "c3bf1770-32d0-40ab-8a6b-2c201eea7e1d",
                                     "name": "Get Beslagen Kadastraal Onroerende Zaak",
                                     "request": {
                                         "name": "Get Beslagen Kadastraal Onroerende Zaak",
@@ -4229,7 +4229,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "2db5fb7b-fbba-4e21-a3a0-6ab25d09d4d4",
+                                            "id": "48dc3b18-83c1-4b16-a0b4-756ee5e9c3d6",
                                             "name": "Zoekactie geslaagd\n",
                                             "originalRequest": {
                                                 "url": {
@@ -4295,12 +4295,12 @@
                                                     "value": "application/hal+json"
                                                 }
                                             ],
-                                            "body": "{\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"voluptate dolor ut ut nostrud\"\n  }\n },\n \"_embedded\": {\n  \"beslagen\": [\n   {\n    \"identificatie\": \"esse adipisicing dolore pariat\",\n    \"domein\": \"et nisi cupidatat\",\n    \"aandeelInBetrokkenRecht\": {\n     \"noemer\": 2,\n     \"teller\": 1\n    },\n    \"gedeeltelijkeBezwaringOudObject\": false,\n    \"omschrijvingBetrokkenRecht\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"toelichtingBewaarder\": \"deser\",\n    \"aard\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"aantekeningen\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"beslagleggers\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"bedragVordering\": {\n     \"som\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"valuta\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"stukIdentificaties\": [\n     \"dolore Duis culpa enim Excepteur\",\n     \"occaecat consequat\"\n    ],\n    \"isGebaseerdOpStukdeelIdentificatie\": \"irure Excepteur\",\n    \"isVermeldInStukdeelIdentificaties\": [\n     \"pariatur\",\n     \"occaecat nulla\"\n    ],\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"consequat esse labore magna\"\n     },\n     \"beslagleggers\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isGebaseerdOpStukdeel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"dolore sunt\"\n     },\n     \"isVermeldInStukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   },\n   {\n    \"identificatie\": \"aute in\",\n    \"domein\": \"dolore sit\",\n    \"aandeelInBetrokkenRecht\": {\n     \"noemer\": 2,\n     \"teller\": 1\n    },\n    \"gedeeltelijkeBezwaringOudObject\": true,\n    \"omschrijvingBetrokkenRecht\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"toelichtingBewaarder\": \"pariatur ad aute occaecat\",\n    \"aard\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"aantekeningen\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"beslagleggers\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"bedragVordering\": {\n     \"som\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"valuta\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"stukIdentificaties\": [\n     \"nisi aute ut\",\n     \"ve\"\n    ],\n    \"isGebaseerdOpStukdeelIdentificatie\": \"amet ullamco dolor magna reprehenderit\",\n    \"isVermeldInStukdeelIdentificaties\": [\n     \"nulla aute\",\n     \"sed dolor\"\n    ],\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"commodo esse\"\n     },\n     \"beslagleggers\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isGebaseerdOpStukdeel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"est reprehenderit\"\n     },\n     \"isVermeldInStukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   }\n  ]\n }\n}",
+                                            "body": "{\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"nulla sit dolor\"\n  }\n },\n \"_embedded\": {\n  \"beslagen\": [\n   {\n    \"identificatie\": \"veniam exercitation\",\n    \"domein\": \"\",\n    \"aandeelInBetrokkenRecht\": {\n     \"noemer\": 2,\n     \"teller\": 1\n    },\n    \"gedeeltelijkeBezwaringOudObject\": true,\n    \"omschrijvingBetrokkenRecht\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"toelichtingBewaarder\": \"sit Ut\",\n    \"aard\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"aantekeningen\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"beslagleggers\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"bedragVordering\": {\n     \"som\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"valuta\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"stukIdentificaties\": [\n     \"dolor\",\n     \"proident amet ipsum\"\n    ],\n    \"isGebaseerdOpStukdeelIdentificatie\": \"fugiat proid\",\n    \"isVermeldInStukdeelIdentificaties\": [\n     \"amet enim\",\n     \"in est\"\n    ],\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"sed aliqua proident irure\"\n     },\n     \"beslagleggers\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isGebaseerdOpStukdeel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"et nostrud proident sunt\"\n     },\n     \"isVermeldInStukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   },\n   {\n    \"identificatie\": \"enim sit proident\",\n    \"domein\": \"amet magna cillum ullamco occaecat\",\n    \"aandeelInBetrokkenRecht\": {\n     \"noemer\": 2,\n     \"teller\": 1\n    },\n    \"gedeeltelijkeBezwaringOudObject\": false,\n    \"omschrijvingBetrokkenRecht\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"toelichtingBewaarder\": \"est ut\",\n    \"aard\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"aantekeningen\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"beslagleggers\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"bedragVordering\": {\n     \"som\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"valuta\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"stukIdentificaties\": [\n     \"ad\",\n     \"dolor laborum sed\"\n    ],\n    \"isGebaseerdOpStukdeelIdentificatie\": \"Excepteur culpa mollit\",\n    \"isVermeldInStukdeelIdentificaties\": [\n     \"et laboris consectetur voluptate\",\n     \"Ut nisi est\"\n    ],\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"pariatur\"\n     },\n     \"beslagleggers\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isGebaseerdOpStukdeel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"aliqua sunt\"\n     },\n     \"isVermeldInStukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   }\n  ]\n }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "5804a8c1-0033-43ba-ba86-051d24bb8eaa",
+                                            "id": "38e2753a-43e1-4774-8094-83da2cdfef75",
                                             "name": "Bad Request",
                                             "originalRequest": {
                                                 "url": {
@@ -4361,7 +4361,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "83bf7c65-b53f-4482-8b98-775f93176658",
+                                            "id": "368b050d-9412-4a4f-aa16-b02b537b337c",
                                             "name": "Unauthorized",
                                             "originalRequest": {
                                                 "url": {
@@ -4422,7 +4422,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "e7847581-95d5-4a70-8ddb-c7f6a430c81b",
+                                            "id": "1999b46f-db33-4ef5-bcb6-1cb5445ae886",
                                             "name": "Forbidden",
                                             "originalRequest": {
                                                 "url": {
@@ -4483,7 +4483,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "60f547bc-6a88-46f4-90f5-a9f33429a6cd",
+                                            "id": "dd3c9ffe-90f8-4994-a827-f439361dd16f",
                                             "name": "Not Found",
                                             "originalRequest": {
                                                 "url": {
@@ -4544,7 +4544,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "60da7a06-69bc-4838-8c2e-43b14e599cd9",
+                                            "id": "e4007bed-3011-4dc4-96c4-d4709b729338",
                                             "name": "Not Acceptable",
                                             "originalRequest": {
                                                 "url": {
@@ -4605,7 +4605,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "201d394b-d1d8-4b4b-92b9-4fd837242ecd",
+                                            "id": "1ae551fb-aa9b-4ccd-a781-2c1d52dabcd2",
                                             "name": "Gone",
                                             "originalRequest": {
                                                 "url": {
@@ -4666,7 +4666,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "c0e6b192-5691-4f53-8721-3a565c186f89",
+                                            "id": "7f493d56-5267-4ea5-bfb8-9f49eb1f64d7",
                                             "name": "Internal Server Error",
                                             "originalRequest": {
                                                 "url": {
@@ -4727,7 +4727,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "ff78c568-b661-4d68-8f9d-3b4b0191626c",
+                                            "id": "efc97eff-6139-481f-b259-8150f1db03d2",
                                             "name": "Service Unavailable",
                                             "originalRequest": {
                                                 "url": {
@@ -4791,7 +4791,7 @@
                                     "event": []
                                 },
                                 {
-                                    "id": "73c8cefd-4f0f-448a-95aa-f8cea287eefa",
+                                    "id": "3711b6c6-4b8e-476d-b225-cf42ba87da83",
                                     "name": "Get Beslag",
                                     "request": {
                                         "name": "Get Beslag",
@@ -4843,7 +4843,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "10f41023-a79c-44ef-bbf7-b58a365d9ad3",
+                                            "id": "4bf94709-da1c-45e2-82b7-effb0ce96b35",
                                             "name": "Raadplegen geslaagd\n",
                                             "originalRequest": {
                                                 "url": {
@@ -4914,12 +4914,12 @@
                                                     "value": "application/hal+json"
                                                 }
                                             ],
-                                            "body": "{\n \"identificatie\": \"sed proident\",\n \"domein\": \"Excepteur aute consectetur\",\n \"aandeelInBetrokkenRecht\": {\n  \"noemer\": 2,\n  \"teller\": 1\n },\n \"gedeeltelijkeBezwaringOudObject\": true,\n \"omschrijvingBetrokkenRecht\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"toelichtingBewaarder\": \"aute Lorem\",\n \"aard\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"aantekeningen\": [\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n ],\n \"beslagleggers\": [\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n ],\n \"bedragVordering\": {\n  \"som\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"valuta\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"stukIdentificaties\": [\n  \"quis Lorem veniam ullamco dolor\",\n  \"ullamco Lorem voluptate\"\n ],\n \"isGebaseerdOpStukdeelIdentificatie\": \"ut consectetur dolor cillum\",\n \"isVermeldInStukdeelIdentificaties\": [\n  \"in ex in sed\",\n  \"Excepteur cillum\"\n ],\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"et aute exercitation nulla\"\n  },\n  \"beslagleggers\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"stukken\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"isGebaseerdOpStukdeel\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"nulla dolor esse magna\"\n  },\n  \"isVermeldInStukdelen\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ]\n }\n}",
+                                            "body": "{\n \"identificatie\": \"nulla sunt amet tempor\",\n \"domein\": \"nulla esse nisi\",\n \"aandeelInBetrokkenRecht\": {\n  \"noemer\": 2,\n  \"teller\": 1\n },\n \"gedeeltelijkeBezwaringOudObject\": false,\n \"omschrijvingBetrokkenRecht\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"toelichtingBewaarder\": \"Ut sunt dolore nostrud\",\n \"aard\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"aantekeningen\": [\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n ],\n \"beslagleggers\": [\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n ],\n \"bedragVordering\": {\n  \"som\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"valuta\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"stukIdentificaties\": [\n  \"nulla Lorem\",\n  \"labore aute\"\n ],\n \"isGebaseerdOpStukdeelIdentificatie\": \"Ut ullamco do\",\n \"isVermeldInStukdeelIdentificaties\": [\n  \"magna \",\n  \"aute anim culpa mollit\"\n ],\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"in do ex laborum labore\"\n  },\n  \"beslagleggers\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"stukken\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"isGebaseerdOpStukdeel\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"incididunt consectetur et nostrud elit\"\n  },\n  \"isVermeldInStukdelen\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ]\n }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "a16189a9-ae0b-4c91-8090-307caac4beda",
+                                            "id": "13d767b6-d88f-4877-98df-bb3a4242703a",
                                             "name": "Bad Request",
                                             "originalRequest": {
                                                 "url": {
@@ -4985,7 +4985,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "bac3363b-e568-45df-af3d-642a05bf7f4f",
+                                            "id": "29a88c83-dbf3-48a1-af77-87dec10c2d38",
                                             "name": "Unauthorized",
                                             "originalRequest": {
                                                 "url": {
@@ -5051,7 +5051,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "911e2fce-9e7a-43d0-ab1a-51802a85f640",
+                                            "id": "bdc94d60-fc93-4cf8-8c64-bf8c37df32d9",
                                             "name": "Forbidden",
                                             "originalRequest": {
                                                 "url": {
@@ -5117,7 +5117,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "3f0da9ec-b843-4831-8ac7-9ff9f6ebcc02",
+                                            "id": "80131df8-48cc-4182-9cc7-d14b0bd8dcfd",
                                             "name": "Not Found",
                                             "originalRequest": {
                                                 "url": {
@@ -5183,7 +5183,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "2888aa6a-2101-4724-87c5-1ee06d97c48a",
+                                            "id": "2a521a0e-8923-4cac-9f77-ebdba780d788",
                                             "name": "Not Acceptable",
                                             "originalRequest": {
                                                 "url": {
@@ -5249,7 +5249,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "92f6beb2-f07e-4117-bcce-0180355b638c",
+                                            "id": "bdcb562e-319f-4bd2-9f5d-58fb86f2e024",
                                             "name": "Gone",
                                             "originalRequest": {
                                                 "url": {
@@ -5315,7 +5315,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "6105c4c0-62f5-4fb2-b0b0-213724be571b",
+                                            "id": "db469ef8-f5da-40d4-a3b5-e7a82d044449",
                                             "name": "Precondition failed",
                                             "originalRequest": {
                                                 "url": {
@@ -5381,7 +5381,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "fc2f2f5c-d2b6-4753-94ad-86f64650f02a",
+                                            "id": "057b4187-0b38-4fc7-95fd-0e5ac19b0124",
                                             "name": "Unsupported Media Type",
                                             "originalRequest": {
                                                 "url": {
@@ -5447,7 +5447,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "239adb14-d548-4b10-b3e0-f015d6950ffe",
+                                            "id": "a53b6601-b207-4528-a85e-d0b2d06163c1",
                                             "name": "Internal Server Error",
                                             "originalRequest": {
                                                 "url": {
@@ -5513,7 +5513,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "b60c1f7b-3721-4ac5-acc0-c27e318181f8",
+                                            "id": "f573c821-d990-447d-b774-4b53d1ca1c47",
                                             "name": "Service Unavailable",
                                             "originalRequest": {
                                                 "url": {
@@ -5585,11 +5585,11 @@
                             "event": []
                         },
                         {
-                            "id": "a6431584-17fd-4a75-8c18-9bff78c26dd9",
+                            "id": "f5810f8e-e087-4df1-a7f2-2ed4a7e6d9b8",
                             "name": "privaatrechtelijkebeperkingen",
                             "item": [
                                 {
-                                    "id": "31ea49f5-2c16-4f70-abf4-47fb08b689b7",
+                                    "id": "bdac4e62-a191-4025-b7fa-c852ba39fca2",
                                     "name": "Get Privaatrechtelijke Beperkingen",
                                     "request": {
                                         "name": "Get Privaatrechtelijke Beperkingen",
@@ -5634,7 +5634,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "1af38251-233d-4498-a221-6fafa868f63c",
+                                            "id": "8ade45eb-44ce-4f72-bbcb-aabafd936099",
                                             "name": "Zoekactie geslaagd\n",
                                             "originalRequest": {
                                                 "url": {
@@ -5700,12 +5700,12 @@
                                                     "value": "application/hal+json"
                                                 }
                                             ],
-                                            "body": "{\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"in minim\"\n  }\n },\n \"_embedded\": {\n  \"privaatrechtelijkeBeperkingen\": [\n   {\n    \"aard\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"omschrijving\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"betreftGedeelteVanPerceel\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"identificatie\": \"dolor amet cupidatat\",\n    \"domein\": \"aliquip ad dolore ea adipisicing\",\n    \"einddatum\": \"2001-03-25\",\n    \"einddatumRecht\": \"1956-09-24\",\n    \"stukIdentificaties\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"isGebaseerdOpStukdeelIdentificatie\": \"in aliquip\",\n    \"isVermeldInStukdeelIdentificaties\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"ut est\"\n     },\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isGebaseerdOpStukdeel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"\"\n     },\n     \"isVermeldInStukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   },\n   {\n    \"aard\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"omschrijving\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"betreftGedeelteVanPerceel\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"identificatie\": \"et laboris aute aliquip\",\n    \"domein\": \"est id do\",\n    \"einddatum\": \"1983-10-26\",\n    \"einddatumRecht\": \"2014-10-19\",\n    \"stukIdentificaties\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"isGebaseerdOpStukdeelIdentificatie\": \"id reprehenderit Duis\",\n    \"isVermeldInStukdeelIdentificaties\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"minim fugiat sed sit\"\n     },\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isGebaseerdOpStukdeel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"in dolor amet fugiat in\"\n     },\n     \"isVermeldInStukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   }\n  ]\n }\n}",
+                                            "body": "{\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"proident\"\n  }\n },\n \"_embedded\": {\n  \"privaatrechtelijkeBeperkingen\": [\n   {\n    \"aard\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"omschrijving\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"betreftGedeelteVanPerceel\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"identificatie\": \"ad fugiat do ea Excepteur\",\n    \"domein\": \"proident incididunt sint irure\",\n    \"einddatum\": \"1976-01-14\",\n    \"einddatumRecht\": \"1948-06-17\",\n    \"stukIdentificaties\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"isGebaseerdOpStukdeelIdentificatie\": \"in\",\n    \"isVermeldInStukdeelIdentificaties\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"occaecat ullamco\"\n     },\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isGebaseerdOpStukdeel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"occaecat\"\n     },\n     \"isVermeldInStukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   },\n   {\n    \"aard\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"omschrijving\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"betreftGedeelteVanPerceel\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"identificatie\": \"nostrud est adip\",\n    \"domein\": \"minim deserunt velit non\",\n    \"einddatum\": \"2013-05-21\",\n    \"einddatumRecht\": \"2010-01-03\",\n    \"stukIdentificaties\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"isGebaseerdOpStukdeelIdentificatie\": \"commodo qui do aliqua\",\n    \"isVermeldInStukdeelIdentificaties\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"ad in officia\"\n     },\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isGebaseerdOpStukdeel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"sint pariatur\"\n     },\n     \"isVermeldInStukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   }\n  ]\n }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "7015dc07-6c54-4555-8ac7-0b6e9283c202",
+                                            "id": "4c08f410-3251-4c2e-a4d0-9c34e65e2eed",
                                             "name": "Bad Request",
                                             "originalRequest": {
                                                 "url": {
@@ -5766,7 +5766,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "8ca43da8-fc98-48c9-960e-3b1395b08e06",
+                                            "id": "a136a6f0-9af6-48fd-9f40-865a0f64c45d",
                                             "name": "Unauthorized",
                                             "originalRequest": {
                                                 "url": {
@@ -5827,7 +5827,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "4c4d85dc-e295-45ac-99e0-b1a8bcfceff4",
+                                            "id": "21e6a529-0467-4a29-afe7-c96a6bbc27fe",
                                             "name": "Forbidden",
                                             "originalRequest": {
                                                 "url": {
@@ -5888,7 +5888,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "cfc2327e-ada2-4717-a0a6-63c9f07aff11",
+                                            "id": "fd474810-96ab-4b72-95e4-40a3857a24b4",
                                             "name": "Not Found",
                                             "originalRequest": {
                                                 "url": {
@@ -5949,7 +5949,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "386ff67d-daa2-44bb-aab2-da0921678825",
+                                            "id": "7ad708c8-4998-40ca-b91f-e4b67bd590c4",
                                             "name": "Not Acceptable",
                                             "originalRequest": {
                                                 "url": {
@@ -6010,7 +6010,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "e30c914f-4ade-471a-8fa5-302be6ede274",
+                                            "id": "ca05d4c3-3c01-4296-bb58-fc670526672a",
                                             "name": "Gone",
                                             "originalRequest": {
                                                 "url": {
@@ -6071,7 +6071,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "4f1a61a7-0e2c-4391-9609-641bb470fdd4",
+                                            "id": "494ef151-bcaa-427d-9db6-2399a7d59397",
                                             "name": "Internal Server Error",
                                             "originalRequest": {
                                                 "url": {
@@ -6132,7 +6132,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "f582597c-9fe4-445c-a4bc-00b96c00a68e",
+                                            "id": "0fdb7b56-77f0-49e8-b264-4ab831ee6c81",
                                             "name": "Service Unavailable",
                                             "originalRequest": {
                                                 "url": {
@@ -6196,7 +6196,7 @@
                                     "event": []
                                 },
                                 {
-                                    "id": "fb95cb7e-9bfe-46a4-a40b-848532219201",
+                                    "id": "6e956272-fe63-4b4d-888b-8bf4118b4372",
                                     "name": "Get Privaatrechtelijke Beperking",
                                     "request": {
                                         "name": "Get Privaatrechtelijke Beperking",
@@ -6248,7 +6248,7 @@
                                     },
                                     "response": [
                                         {
-                                            "id": "561deb63-b1f3-4054-bf75-29eb513592c8",
+                                            "id": "21caac89-57aa-443e-a03e-d7a0664a71dd",
                                             "name": "Zoekactie geslaagd\n",
                                             "originalRequest": {
                                                 "url": {
@@ -6319,12 +6319,12 @@
                                                     "value": "application/hal+json"
                                                 }
                                             ],
-                                            "body": "{\n \"aard\": {\n  \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n },\n \"omschrijving\": {\n  \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n },\n \"betreftGedeelteVanPerceel\": {\n  \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n },\n \"identificatie\": \"magna enim proident dolore\",\n \"domein\": \"nulla ex ullamco fugiat\",\n \"einddatum\": \"1991-05-24\",\n \"einddatumRecht\": \"1954-12-04\",\n \"stukIdentificaties\": [\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n ],\n \"isGebaseerdOpStukdeelIdentificatie\": \"exercitation\",\n \"isVermeldInStukdeelIdentificaties\": [\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n ],\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"officia veniam\"\n  },\n  \"stukken\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"isGebaseerdOpStukdeel\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"ad officia\"\n  },\n  \"isVermeldInStukdelen\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ]\n }\n}",
+                                            "body": "{\n \"aard\": {\n  \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n },\n \"omschrijving\": {\n  \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n },\n \"betreftGedeelteVanPerceel\": {\n  \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n },\n \"identificatie\": \"proident cillum dolore occaecat\",\n \"domein\": \"in labore\",\n \"einddatum\": \"1960-08-04\",\n \"einddatumRecht\": \"2016-05-30\",\n \"stukIdentificaties\": [\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n ],\n \"isGebaseerdOpStukdeelIdentificatie\": \"sint su\",\n \"isVermeldInStukdeelIdentificaties\": [\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n ],\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"in\"\n  },\n  \"stukken\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"isGebaseerdOpStukdeel\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"sint Lorem dolor Excepteur culpa\"\n  },\n  \"isVermeldInStukdelen\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ]\n }\n}",
                                             "cookie": [],
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "26e7165c-5bef-4066-bb6d-c7aad0ece9ff",
+                                            "id": "28e19389-9ee1-4da5-be08-f74c54c60188",
                                             "name": "Bad Request",
                                             "originalRequest": {
                                                 "url": {
@@ -6390,7 +6390,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "69303a7b-79be-4c81-89a1-8a14053eae05",
+                                            "id": "3c937e12-6e45-4e22-b573-fe54d91a0a0d",
                                             "name": "Unauthorized",
                                             "originalRequest": {
                                                 "url": {
@@ -6456,7 +6456,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "3a8429c0-8edf-4fe9-ba7f-a44b73a7eb83",
+                                            "id": "912b874f-3d59-43a1-bf4d-29e250bdbfe5",
                                             "name": "Forbidden",
                                             "originalRequest": {
                                                 "url": {
@@ -6522,7 +6522,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "e463be97-11c8-4e64-9bfe-0a078f8e7b02",
+                                            "id": "8db7be95-3b8b-4595-b4c4-9e545792795c",
                                             "name": "Not Found",
                                             "originalRequest": {
                                                 "url": {
@@ -6588,7 +6588,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "fe8a39de-e044-49de-9294-0ed1070573e9",
+                                            "id": "82f96d0a-10b9-42a7-807c-7f8d14744840",
                                             "name": "Not Acceptable",
                                             "originalRequest": {
                                                 "url": {
@@ -6654,7 +6654,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "b39213e2-e322-4be0-a77e-4e651ded82c5",
+                                            "id": "60d98c83-c7b2-45d7-bf7e-6919c94ad010",
                                             "name": "Gone",
                                             "originalRequest": {
                                                 "url": {
@@ -6720,7 +6720,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "11c6e900-7e10-4cdf-b5eb-a2b665f172e9",
+                                            "id": "a2aae00f-b495-4cfe-a07c-392df7457646",
                                             "name": "Internal Server Error",
                                             "originalRequest": {
                                                 "url": {
@@ -6786,7 +6786,7 @@
                                             "_postman_previewlanguage": "json"
                                         },
                                         {
-                                            "id": "c1e9fa4c-8171-41a4-a004-b0bee0a2e709",
+                                            "id": "3149fb9e-9559-47ac-ae33-df59bf2de5db",
                                             "name": "Service Unavailable",
                                             "originalRequest": {
                                                 "url": {
@@ -6864,11 +6864,11 @@
             "event": []
         },
         {
-            "id": "7320b662-5836-4154-85b6-31b11129ae0b",
+            "id": "c5ab2376-c5e4-4975-a606-218663569b20",
             "name": "kadasternatuurlijkpersonen",
             "item": [
                 {
-                    "id": "0eaf3127-4ee2-43e5-976d-d68dd997e73e",
+                    "id": "bdda360b-e250-4928-9084-4fdef2872629",
                     "name": "Get Kadaster Personen",
                     "request": {
                         "name": "Get Kadaster Personen",
@@ -6902,7 +6902,7 @@
                     },
                     "response": [
                         {
-                            "id": "3eaecd5a-1e47-41f1-b25c-8d2e88a24c27",
+                            "id": "b8f426ee-219d-4540-b782-282f0baddf83",
                             "name": "Zoekactie geslaagd\n",
                             "originalRequest": {
                                 "url": {
@@ -6955,12 +6955,12 @@
                                     "value": "application/hal+json"
                                 }
                             ],
-                            "body": "{\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"id ad occaecat in in\"\n  }\n },\n \"_embedded\": {\n  \"kadasterNatuurlijkPersonen\": [\n   {\n    \"geheimhoudingPersoonsgegevens\": true,\n    \"landWaarnaarVertrokken\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"geslachtsaanduiding\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"heeftPartnerschap\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"naam\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"geboorte\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"overlijden\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"aliqua proident\"\n     },\n     \"woonadres\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"in laboris sint\"\n     },\n     \"postadres\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"ipsum ut\"\n     },\n     \"kadastraalOnroerendeZaken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"zakelijkGerechtigden\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   },\n   {\n    \"geheimhoudingPersoonsgegevens\": false,\n    \"landWaarnaarVertrokken\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"geslachtsaanduiding\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"heeftPartnerschap\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"naam\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"geboorte\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"overlijden\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"in dolore ut dolor\"\n     },\n     \"woonadres\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"Excepteur\"\n     },\n     \"postadres\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"voluptate eiusmod tempor\"\n     },\n     \"kadastraalOnroerendeZaken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"zakelijkGerechtigden\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   }\n  ]\n }\n}",
+                            "body": "{\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"tempor Excepteur irure labore\"\n  }\n },\n \"_embedded\": {\n  \"kadasterNatuurlijkPersonen\": [\n   {\n    \"geheimhoudingPersoonsgegevens\": true,\n    \"landWaarnaarVertrokken\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"geslachtsaanduiding\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"heeftPartnerschap\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"naam\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"geboorte\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"overlijden\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"null\"\n     },\n     \"woonadres\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"id ea Excepteur officia\"\n     },\n     \"postadres\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"dolore et in\"\n     },\n     \"kadastraalOnroerendeZaken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"zakelijkGerechtigden\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   },\n   {\n    \"geheimhoudingPersoonsgegevens\": true,\n    \"landWaarnaarVertrokken\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"geslachtsaanduiding\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"heeftPartnerschap\": [\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    ],\n    \"naam\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"geboorte\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"overlijden\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"dolor consectetur amet in\"\n     },\n     \"woonadres\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"est dolor\"\n     },\n     \"postadres\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"ut\"\n     },\n     \"kadastraalOnroerendeZaken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"zakelijkGerechtigden\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   }\n  ]\n }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "520b7d5e-f301-4e43-850e-fb5c669cad1d",
+                            "id": "c835e2af-1ef1-4189-bf1b-045b048ffed4",
                             "name": "Bad Request",
                             "originalRequest": {
                                 "url": {
@@ -7013,7 +7013,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a22df2b1-8653-4a17-9e01-3e54ed1b7ee3",
+                            "id": "8d59a9f3-e3d5-49e0-80df-5f7dc252fd98",
                             "name": "Unauthorized",
                             "originalRequest": {
                                 "url": {
@@ -7066,7 +7066,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "3a3927ee-2ccf-45ae-bc5c-8caaeaa9bad1",
+                            "id": "5d3363fe-b947-4c02-8f2d-7bca51bc605d",
                             "name": "Forbidden",
                             "originalRequest": {
                                 "url": {
@@ -7119,7 +7119,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2f77807b-5840-4d47-8dc8-8d72678f1b56",
+                            "id": "cc849e55-3242-4902-8333-43aae89531c2",
                             "name": "Not Acceptable",
                             "originalRequest": {
                                 "url": {
@@ -7172,7 +7172,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "6d2126b1-d361-4163-886c-56802f0d4528",
+                            "id": "ad1811b3-31c0-420f-9696-2771ca19841d",
                             "name": "Gone",
                             "originalRequest": {
                                 "url": {
@@ -7225,7 +7225,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a3698443-ae69-4df1-8958-682c0a35edc7",
+                            "id": "fb58afc4-ed41-43af-9f8f-a515a300e26f",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -7278,7 +7278,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1704c1b5-a902-48ae-b31a-a9bf4e01c3c1",
+                            "id": "44255432-0021-4939-b0d6-6849db7fd689",
                             "name": "Service Unavailable",
                             "originalRequest": {
                                 "url": {
@@ -7334,7 +7334,7 @@
                     "event": []
                 },
                 {
-                    "id": "9e3bf67b-801c-474f-8608-51f6855cb6c0",
+                    "id": "adca61eb-04c7-4ff1-97c1-a75597c0c9b6",
                     "name": "Get Kadaster Persoon",
                     "request": {
                         "name": "Get Kadaster Persoon",
@@ -7371,7 +7371,7 @@
                     },
                     "response": [
                         {
-                            "id": "d6459647-8e75-497e-92b6-72dd7125b3d0",
+                            "id": "36cd40bb-1242-4fd6-8394-d6853fa3ebfa",
                             "name": "Zoekactie geslaagd\n",
                             "originalRequest": {
                                 "url": {
@@ -7426,12 +7426,12 @@
                                     "value": "application/hal+json"
                                 }
                             ],
-                            "body": "{\n \"identificatie\": \"in voluptate\",\n \"omschrijving\": \"consequat aliquip\",\n \"domein\": \"ad in laborum anim\",\n \"indicatieNietToonbareDiakriet\": false,\n \"beschikkingsbevoegdheid\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"woonadres\": {\n  \"straat\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"huisnummer\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"huisletter\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"huisnummertoevoeging\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"postcode\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"woonplaats\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"nummeraanduidingIdentificatie\": \"1234207890123456\",\n  \"adresregel1\": \"Laan van de landinrichtingscommissie Duiven-Westervoort 1A-bis\",\n  \"adresregel2\": \"6922KZ  Duiven\",\n  \"adresregel3\": \"Selangor\",\n  \"land\": {\n   \"code\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   \"waarde\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  }\n },\n \"postadres\": {\n  \"postbusnummer\": 1021,\n  \"postcode\": \"1234AA\",\n  \"woonplaats\": \"Nootdorp\",\n  \"adresregel1\": \"Postbus 1021\",\n  \"adresregel2\": \"1234AA Nootdorp\"\n },\n \"kadastraalOnroerendeZaakIdentificaties\": [\n  \"proident eiusmod pariatur c\",\n  \"ex Ut culpa\"\n ],\n \"geheimhoudingPersoonsgegevens\": true,\n \"landWaarnaarVertrokken\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"geslachtsaanduiding\": \"onbekend\",\n \"heeftPartnerschap\": [\n  {\n   \"datumOntbinding\": {\n    \"dag\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"datum\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"jaar\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"maand\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    }\n   },\n   \"datumSluiting\": {\n    \"dag\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"datum\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"jaar\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"maand\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    }\n   },\n   \"naam\": {\n    \"geslachtsnaam\": \"est deserunt Duis\",\n    \"voornamen\": \"magna non\",\n    \"voorvoegsel\": \"non eiusmo\"\n   }\n  },\n  {\n   \"datumOntbinding\": {\n    \"dag\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"datum\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"jaar\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"maand\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    }\n   },\n   \"datumSluiting\": {\n    \"dag\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"datum\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"jaar\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"maand\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    }\n   },\n   \"naam\": {\n    \"geslachtsnaam\": \"occaecat\",\n    \"voornamen\": \"ea\",\n    \"voorvoegsel\": \"pariatur es\"\n   }\n  }\n ],\n \"naam\": {\n  \"geslachtsnaam\": \"officia commodo dolore\",\n  \"voornamen\": \"aute \",\n  \"voorvoegsel\": \"enim ut eiusmod sint\",\n  \"aanschrijfwijze\": \"G.H I. In het Veld-van Velzen\",\n  \"aanhef\": \"Geachte mevrouw In het Veld-van Velzen\",\n  \"gebruikInLopendeTekst\": \"mevrouw In het Veld-van Velzen\"\n },\n \"geboorte\": {\n  \"plaats\": \"nulla id amet laboris\",\n  \"datum\": {\n   \"dag\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   \"datum\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   \"jaar\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   \"maand\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  },\n  \"land\": {\n   \"code\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   \"waarde\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  }\n },\n \"overlijden\": {\n  \"datum\": {\n   \"dag\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   \"datum\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   \"jaar\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   \"maand\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  }\n },\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"in deserunt\"\n  },\n  \"woonadres\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"est Lorem\"\n  },\n  \"postadres\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"qui cupidatat aliqua quis tempor\"\n  },\n  \"kadastraalOnroerendeZaken\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"zakelijkGerechtigden\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ]\n }\n}",
+                            "body": "{\n \"identificatie\": \"enim Ut voluptate\",\n \"omschrijving\": \"nisi adipisicing sunt et ea\",\n \"domein\": \"veniam et nulla dolor\",\n \"indicatieNietToonbareDiakriet\": true,\n \"beschikkingsbevoegdheid\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"woonadres\": {\n  \"straat\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"huisnummer\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"huisletter\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"huisnummertoevoeging\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"postcode\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"woonplaats\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"nummeraanduidingIdentificatie\": \"1234207890123456\",\n  \"adresregel1\": \"Laan van de landinrichtingscommissie Duiven-Westervoort 1A-bis\",\n  \"adresregel2\": \"6922KZ  Duiven\",\n  \"adresregel3\": \"Selangor\",\n  \"land\": {\n   \"code\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   \"waarde\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  }\n },\n \"postadres\": {\n  \"postbusnummer\": 1021,\n  \"postcode\": \"1234AA\",\n  \"woonplaats\": \"Nootdorp\",\n  \"adresregel1\": \"Postbus 1021\",\n  \"adresregel2\": \"1234AA Nootdorp\"\n },\n \"kadastraalOnroerendeZaakIdentificaties\": [\n  \"incididunt nostrud ullamco sunt esse\",\n  \"consectetur laborum nisi ea\"\n ],\n \"geheimhoudingPersoonsgegevens\": true,\n \"landWaarnaarVertrokken\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"geslachtsaanduiding\": \"vrouw\",\n \"heeftPartnerschap\": [\n  {\n   \"datumOntbinding\": {\n    \"dag\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"datum\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"jaar\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"maand\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    }\n   },\n   \"datumSluiting\": {\n    \"dag\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"datum\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"jaar\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"maand\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    }\n   },\n   \"naam\": {\n    \"geslachtsnaam\": \"sed eu nulla\",\n    \"voornamen\": \"do\",\n    \"voorvoegsel\": \"minim dolore commodo et nostrud\"\n   }\n  },\n  {\n   \"datumOntbinding\": {\n    \"dag\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"datum\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"jaar\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"maand\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    }\n   },\n   \"datumSluiting\": {\n    \"dag\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"datum\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"jaar\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"maand\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    }\n   },\n   \"naam\": {\n    \"geslachtsnaam\": \"minim dolor laboris et culpa\",\n    \"voornamen\": \"occaecat\",\n    \"voorvoegsel\": \"esse in voluptate\"\n   }\n  }\n ],\n \"naam\": {\n  \"geslachtsnaam\": \"aute aliqua\",\n  \"voornamen\": \"f\",\n  \"voorvoegsel\": \"consectetur cupidata\",\n  \"aanschrijfwijze\": \"G.H I. In het Veld-van Velzen\",\n  \"aanhef\": \"Geachte mevrouw In het Veld-van Velzen\",\n  \"gebruikInLopendeTekst\": \"mevrouw In het Veld-van Velzen\"\n },\n \"geboorte\": {\n  \"plaats\": \"Duis et occaecat Excepteur\",\n  \"datum\": {\n   \"dag\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   \"datum\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   \"jaar\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   \"maand\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  },\n  \"land\": {\n   \"code\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   \"waarde\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  }\n },\n \"overlijden\": {\n  \"datum\": {\n   \"dag\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   \"datum\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   \"jaar\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   \"maand\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  }\n },\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"Excepteur proident es\"\n  },\n  \"woonadres\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"dolor elit \"\n  },\n  \"postadres\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"Duis ut voluptate et\"\n  },\n  \"kadastraalOnroerendeZaken\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"zakelijkGerechtigden\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ]\n }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a01232fa-6b67-49fa-a166-19eb68989b5b",
+                            "id": "9cdafcf6-53a3-4e48-a846-1975ee2ed31a",
                             "name": "Bad Request",
                             "originalRequest": {
                                 "url": {
@@ -7486,7 +7486,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "e620c7ec-d7b0-4cb2-afb5-01f5ee47f9ad",
+                            "id": "3867f692-610d-46b4-8ad2-a9515021481d",
                             "name": "Unauthorized",
                             "originalRequest": {
                                 "url": {
@@ -7541,7 +7541,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "5baabf7f-86ea-4a07-8c20-8a5efe51e02e",
+                            "id": "1db953b3-f6d5-4699-bfd3-832c16adbf0c",
                             "name": "Forbidden",
                             "originalRequest": {
                                 "url": {
@@ -7596,7 +7596,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "c89fd5a0-4240-45f6-8789-d22aa9b70e8b",
+                            "id": "67a0261a-f1c4-41c8-90dc-8c5620ebab31",
                             "name": "Not Found",
                             "originalRequest": {
                                 "url": {
@@ -7651,7 +7651,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "32802ea3-8426-4a9a-9903-2641be6e6388",
+                            "id": "0b8f2e98-7e8b-48bb-9545-165bee19e9a5",
                             "name": "Not Acceptable",
                             "originalRequest": {
                                 "url": {
@@ -7706,7 +7706,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "2a335a1d-e885-4b61-95a3-f22b2fdeeef5",
+                            "id": "4376944b-deca-4e61-ab1c-666b5dbef5aa",
                             "name": "Gone",
                             "originalRequest": {
                                 "url": {
@@ -7761,7 +7761,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "fedff6ed-c5ff-4973-be84-78589af98a60",
+                            "id": "97599637-e1e1-48c9-ad88-06318ad373d2",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -7816,7 +7816,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d6bf4ddd-e341-45b7-b493-b113d035380f",
+                            "id": "63886fd6-ed17-485c-b322-73cd6394781f",
                             "name": "Service Unavailable",
                             "originalRequest": {
                                 "url": {
@@ -7877,11 +7877,11 @@
             "event": []
         },
         {
-            "id": "50e5c43f-859e-4e3f-8a50-725da8d2c25f",
+            "id": "4de6c1a4-852c-4c89-a1a0-574e1822bbbe",
             "name": "kadasternietnatuurlijkpersonen",
             "item": [
                 {
-                    "id": "7026e7f4-0316-470b-a0ed-f623c0a2638a",
+                    "id": "142b810b-8911-4f90-9e0b-2e61760278b4",
                     "name": "Get Kadaster Niet Natuurlijk Personen",
                     "request": {
                         "name": "Get Kadaster Niet Natuurlijk Personen",
@@ -7915,7 +7915,7 @@
                     },
                     "response": [
                         {
-                            "id": "ffbfcd47-7659-41f2-9ded-752f613d4da3",
+                            "id": "62b46203-b65b-4189-a265-abb75325e846",
                             "name": "Zoekactie geslaagd\n",
                             "originalRequest": {
                                 "url": {
@@ -7968,12 +7968,12 @@
                                     "value": "application/hal+json"
                                 }
                             ],
-                            "body": "{\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"culpa deserunt velit sed reprehenderit\"\n  }\n },\n \"_embedded\": {\n  \"kadasterNietNatuurlijkPersonen\": [\n   {\n    \"identificatie\": \"aliquip deserunt exercitation labore\",\n    \"omschrijving\": \"aute in\",\n    \"domein\": \"in p\",\n    \"indicatieNietToonbareDiakriet\": true,\n    \"beschikkingsbevoegdheid\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"woonadres\": {\n     \"straat\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"huisnummer\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"huisletter\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"huisnummertoevoeging\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"postcode\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"woonplaats\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"nummeraanduidingIdentificatie\": \"1234207890123456\",\n     \"adresregel1\": \"Laan van de landinrichtingscommissie Duiven-Westervoort 1A-bis\",\n     \"adresregel2\": \"6922KZ  Duiven\",\n     \"adresregel3\": \"Selangor\",\n     \"land\": {\n      \"code\": {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"waarde\": {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     }\n    },\n    \"postadres\": {\n     \"postbusnummer\": 1021,\n     \"postcode\": \"1234AA\",\n     \"woonplaats\": \"Nootdorp\",\n     \"adresregel1\": \"Postbus 1021\",\n     \"adresregel2\": \"1234AA Nootdorp\"\n    },\n    \"kadastraalOnroerendeZaakIdentificaties\": [\n     \"veniam sint\",\n     \"aute Ut cillum dolore\"\n    ],\n    \"statutaireNaam\": \"magna\",\n    \"statutaireZetel\": \"aute cillum\",\n    \"rechtsvorm\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"kvkNummer\": \"proident Lo\",\n    \"rsin\": \"fugiat in Duis\",\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"culpa aliqua in est\"\n     },\n     \"woonadres\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"aute sint aliqua nisi\"\n     },\n     \"postadres\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"ex\"\n     },\n     \"kadastraalOnroerendeZaken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"zakelijkGerechtigden\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   },\n   {\n    \"identificatie\": \"Lorem \",\n    \"omschrijving\": \"consequat sit amet in\",\n    \"domein\": \"dolor ea adipisicing deserunt\",\n    \"indicatieNietToonbareDiakriet\": false,\n    \"beschikkingsbevoegdheid\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"woonadres\": {\n     \"straat\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"huisnummer\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"huisletter\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"huisnummertoevoeging\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"postcode\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"woonplaats\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"nummeraanduidingIdentificatie\": \"1234207890123456\",\n     \"adresregel1\": \"Laan van de landinrichtingscommissie Duiven-Westervoort 1A-bis\",\n     \"adresregel2\": \"6922KZ  Duiven\",\n     \"adresregel3\": \"Selangor\",\n     \"land\": {\n      \"code\": {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"waarde\": {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     }\n    },\n    \"postadres\": {\n     \"postbusnummer\": 1021,\n     \"postcode\": \"1234AA\",\n     \"woonplaats\": \"Nootdorp\",\n     \"adresregel1\": \"Postbus 1021\",\n     \"adresregel2\": \"1234AA Nootdorp\"\n    },\n    \"kadastraalOnroerendeZaakIdentificaties\": [\n     \"in\",\n     \"\"\n    ],\n    \"statutaireNaam\": \"Excepteur officia\",\n    \"statutaireZetel\": \"enim proident incididunt fugiat\",\n    \"rechtsvorm\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"kvkNummer\": \"sit deserunt mollit\",\n    \"rsin\": \"Ut irure\",\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"officia consequat\"\n     },\n     \"woonadres\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"dol\"\n     },\n     \"postadres\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"officia proident\"\n     },\n     \"kadastraalOnroerendeZaken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"zakelijkGerechtigden\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   }\n  ]\n }\n}",
+                            "body": "{\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"aute magna\"\n  }\n },\n \"_embedded\": {\n  \"kadasterNietNatuurlijkPersonen\": [\n   {\n    \"identificatie\": \"ex\",\n    \"omschrijving\": \"exercitation id nostrud\",\n    \"domein\": \"sint nulla dolor\",\n    \"indicatieNietToonbareDiakriet\": true,\n    \"beschikkingsbevoegdheid\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"woonadres\": {\n     \"straat\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"huisnummer\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"huisletter\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"huisnummertoevoeging\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"postcode\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"woonplaats\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"nummeraanduidingIdentificatie\": \"1234207890123456\",\n     \"adresregel1\": \"Laan van de landinrichtingscommissie Duiven-Westervoort 1A-bis\",\n     \"adresregel2\": \"6922KZ  Duiven\",\n     \"adresregel3\": \"Selangor\",\n     \"land\": {\n      \"code\": {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"waarde\": {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     }\n    },\n    \"postadres\": {\n     \"postbusnummer\": 1021,\n     \"postcode\": \"1234AA\",\n     \"woonplaats\": \"Nootdorp\",\n     \"adresregel1\": \"Postbus 1021\",\n     \"adresregel2\": \"1234AA Nootdorp\"\n    },\n    \"kadastraalOnroerendeZaakIdentificaties\": [\n     \"sint et veniam sed pariatur\",\n     \"et in\"\n    ],\n    \"statutaireNaam\": \"eu cupidatat officia\",\n    \"statutaireZetel\": \"anim nostrud\",\n    \"rechtsvorm\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"kvkNummer\": \"sint Ex\",\n    \"rsin\": \"nulla\",\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"dolor aliquip\"\n     },\n     \"woonadres\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"n\"\n     },\n     \"postadres\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"exercitation tempor\"\n     },\n     \"kadastraalOnroerendeZaken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"zakelijkGerechtigden\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   },\n   {\n    \"identificatie\": \"cillum esse\",\n    \"omschrijving\": \"culpa\",\n    \"domein\": \"consectetur non nulla ut\",\n    \"indicatieNietToonbareDiakriet\": true,\n    \"beschikkingsbevoegdheid\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"woonadres\": {\n     \"straat\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"huisnummer\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"huisletter\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"huisnummertoevoeging\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"postcode\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"woonplaats\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"nummeraanduidingIdentificatie\": \"1234207890123456\",\n     \"adresregel1\": \"Laan van de landinrichtingscommissie Duiven-Westervoort 1A-bis\",\n     \"adresregel2\": \"6922KZ  Duiven\",\n     \"adresregel3\": \"Selangor\",\n     \"land\": {\n      \"code\": {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"waarde\": {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     }\n    },\n    \"postadres\": {\n     \"postbusnummer\": 1021,\n     \"postcode\": \"1234AA\",\n     \"woonplaats\": \"Nootdorp\",\n     \"adresregel1\": \"Postbus 1021\",\n     \"adresregel2\": \"1234AA Nootdorp\"\n    },\n    \"kadastraalOnroerendeZaakIdentificaties\": [\n     \"aliquip et esse\",\n     \"sunt adipisicing Excepteur ullamco\"\n    ],\n    \"statutaireNaam\": \"cillum consectetur nostrud dolore\",\n    \"statutaireZetel\": \"laboris officia\",\n    \"rechtsvorm\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"kvkNummer\": \"velit\",\n    \"rsin\": \"cillum officia incididunt\",\n    \"_links\": {\n     \"self\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"aute incididunt sunt\"\n     },\n     \"woonadres\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"sit eu velit dolore\"\n     },\n     \"postadres\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"ipsum aliqua deserunt adipisicing\"\n     },\n     \"kadastraalOnroerendeZaken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"zakelijkGerechtigden\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   }\n  ]\n }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "f1180916-0b24-45c0-8329-d4448073f961",
+                            "id": "26bc49a8-6b8f-4d94-a80a-c51153380db1",
                             "name": "Bad Request",
                             "originalRequest": {
                                 "url": {
@@ -8026,7 +8026,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "6c125c1d-6db2-4bba-8058-98e0aeba126a",
+                            "id": "f5892f23-0ecd-4056-8b61-46cea1e99116",
                             "name": "Unauthorized",
                             "originalRequest": {
                                 "url": {
@@ -8079,7 +8079,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "9b6f65c1-4cac-4409-8e8f-58f106246def",
+                            "id": "9c2655ae-7461-4de1-916d-cccbb121eca4",
                             "name": "Forbidden",
                             "originalRequest": {
                                 "url": {
@@ -8132,7 +8132,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "53685279-44d5-4f3e-b6a9-b26556e5b9bf",
+                            "id": "dbae639b-f9cb-47aa-8d57-c4da3c14920c",
                             "name": "Not Acceptable",
                             "originalRequest": {
                                 "url": {
@@ -8185,7 +8185,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "4c14d969-f722-4fbb-81de-2defdde5d339",
+                            "id": "6ddb5bd2-0d9a-445e-9564-376708921324",
                             "name": "Gone",
                             "originalRequest": {
                                 "url": {
@@ -8238,7 +8238,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "53398fbb-6bad-471b-bfe5-7a37cdb9df33",
+                            "id": "c43dcaf6-5876-4ce9-90d1-cae919d56af9",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -8291,7 +8291,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "a5dc2a0f-e77d-42b7-8906-454a9d35900e",
+                            "id": "d3eb8a62-aebe-4d95-9db1-43c22cb7ef2d",
                             "name": "Service Unavailable",
                             "originalRequest": {
                                 "url": {
@@ -8347,7 +8347,7 @@
                     "event": []
                 },
                 {
-                    "id": "aae7632b-8719-43fd-9f3e-eda346663302",
+                    "id": "c8c35a86-a41f-46ee-b8a3-070ec290d6c4",
                     "name": "Get Kadaster Niet Natuurlijk Persoon",
                     "request": {
                         "name": "Get Kadaster Niet Natuurlijk Persoon",
@@ -8384,7 +8384,7 @@
                     },
                     "response": [
                         {
-                            "id": "d5bdb4a7-ba5a-46cc-a285-f14ca8f35ae4",
+                            "id": "e5fdaa53-dd64-440b-9aea-85a927f546ae",
                             "name": "Zoekactie geslaagd\n",
                             "originalRequest": {
                                 "url": {
@@ -8439,12 +8439,12 @@
                                     "value": "application/hal+json"
                                 }
                             ],
-                            "body": "{\n \"identificatie\": \"sit\",\n \"omschrijving\": \"ad aliquip\",\n \"domein\": \"culpa\",\n \"indicatieNietToonbareDiakriet\": true,\n \"beschikkingsbevoegdheid\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"woonadres\": {\n  \"straat\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"huisnummer\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"huisletter\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"huisnummertoevoeging\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"postcode\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"woonplaats\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"nummeraanduidingIdentificatie\": \"1234207890123456\",\n  \"adresregel1\": \"Laan van de landinrichtingscommissie Duiven-Westervoort 1A-bis\",\n  \"adresregel2\": \"6922KZ  Duiven\",\n  \"adresregel3\": \"Selangor\",\n  \"land\": {\n   \"code\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   \"waarde\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  }\n },\n \"postadres\": {\n  \"postbusnummer\": 1021,\n  \"postcode\": \"1234AA\",\n  \"woonplaats\": \"Nootdorp\",\n  \"adresregel1\": \"Postbus 1021\",\n  \"adresregel2\": \"1234AA Nootdorp\"\n },\n \"kadastraalOnroerendeZaakIdentificaties\": [\n  \"sint\",\n  \"in\"\n ],\n \"statutaireNaam\": \"c\",\n \"statutaireZetel\": \"incididunt te\",\n \"rechtsvorm\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"kvkNummer\": \"aute\",\n \"rsin\": \"qui\",\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"occaecat \"\n  },\n  \"woonadres\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"veniam Lor\"\n  },\n  \"postadres\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"ad \"\n  },\n  \"kadastraalOnroerendeZaken\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"zakelijkGerechtigden\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ]\n }\n}",
+                            "body": "{\n \"identificatie\": \"cillum amet enim reprehenderit\",\n \"omschrijving\": \"commodo des\",\n \"domein\": \"cillum adipisicing sint do irure\",\n \"indicatieNietToonbareDiakriet\": true,\n \"beschikkingsbevoegdheid\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"woonadres\": {\n  \"straat\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"huisnummer\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"huisletter\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"huisnummertoevoeging\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"postcode\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"woonplaats\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"nummeraanduidingIdentificatie\": \"1234207890123456\",\n  \"adresregel1\": \"Laan van de landinrichtingscommissie Duiven-Westervoort 1A-bis\",\n  \"adresregel2\": \"6922KZ  Duiven\",\n  \"adresregel3\": \"Selangor\",\n  \"land\": {\n   \"code\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   \"waarde\": {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  }\n },\n \"postadres\": {\n  \"postbusnummer\": 1021,\n  \"postcode\": \"1234AA\",\n  \"woonplaats\": \"Nootdorp\",\n  \"adresregel1\": \"Postbus 1021\",\n  \"adresregel2\": \"1234AA Nootdorp\"\n },\n \"kadastraalOnroerendeZaakIdentificaties\": [\n  \"dolore ex non dolore\",\n  \"reprehenderit sit incididunt\"\n ],\n \"statutaireNaam\": \"ea\",\n \"statutaireZetel\": \"minim laboris ex aliquip incididunt\",\n \"rechtsvorm\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"kvkNummer\": \"exercitation nostrud culpa in\",\n \"rsin\": \"pariatur cillum in dolore\",\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"Ut pariatur\"\n  },\n  \"woonadres\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"laborum anim\"\n  },\n  \"postadres\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"irure dolor ipsum\"\n  },\n  \"kadastraalOnroerendeZaken\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"zakelijkGerechtigden\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ]\n }\n}",
                             "cookie": [],
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "63342f18-6631-4e60-91aa-6ad101b7db1b",
+                            "id": "c5798436-4b50-4a2a-9a59-2761a68799c5",
                             "name": "Bad Request",
                             "originalRequest": {
                                 "url": {
@@ -8499,7 +8499,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "211e76c8-a441-4c23-85cd-1afb7b61aab4",
+                            "id": "745ffa53-630a-4911-ac75-44344bc13067",
                             "name": "Unauthorized",
                             "originalRequest": {
                                 "url": {
@@ -8554,7 +8554,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "d2b33c97-9b39-4d6a-925e-00a7d110de68",
+                            "id": "225f6051-fe98-499e-ad93-5c57b5a4661d",
                             "name": "Forbidden",
                             "originalRequest": {
                                 "url": {
@@ -8609,7 +8609,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "b355f7b1-9ca0-4da0-bd3d-42baf4d49bd6",
+                            "id": "f386b76e-46f9-48cc-bd99-616ea39ef7fb",
                             "name": "Not Found",
                             "originalRequest": {
                                 "url": {
@@ -8664,7 +8664,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "118feee3-5cbf-4b17-94ba-3866b4ae93e9",
+                            "id": "098e2fe0-46de-4e2b-a3a9-3437567ec65c",
                             "name": "Not Acceptable",
                             "originalRequest": {
                                 "url": {
@@ -8719,7 +8719,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "4d2f93ff-6fb3-4af1-ad09-e39c67249f04",
+                            "id": "91f6d2e9-3ce8-441f-8cda-2ec691e40b76",
                             "name": "Gone",
                             "originalRequest": {
                                 "url": {
@@ -8774,7 +8774,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "eede33b2-152d-4ada-90a5-c8af7851e55d",
+                            "id": "5eda456c-1432-48e6-b901-1a1c2aad1f4c",
                             "name": "Internal Server Error",
                             "originalRequest": {
                                 "url": {
@@ -8829,7 +8829,7 @@
                             "_postman_previewlanguage": "json"
                         },
                         {
-                            "id": "1551dda2-ea17-4f6e-8f3c-a223c08893c3",
+                            "id": "1b0bab02-6272-4360-af5d-82aa69ad681d",
                             "name": "Service Unavailable",
                             "originalRequest": {
                                 "url": {
@@ -8890,7 +8890,7 @@
             "event": []
         },
         {
-            "id": "dfe417b8-ac43-4dd5-b7d1-45f6dd728ddd",
+            "id": "b87f150f-7129-43de-a72e-521806502944",
             "name": "Get Publiekrechtelijke Beperkingen",
             "request": {
                 "name": "Get Publiekrechtelijke Beperkingen",
@@ -8924,7 +8924,7 @@
             },
             "response": [
                 {
-                    "id": "f55e7673-5ea9-44ef-bd56-e1937bca01c0",
+                    "id": "e13bd721-e2ac-43a2-9f65-e9e6b14345b8",
                     "name": "Zoekactie geslaagd\n",
                     "originalRequest": {
                         "url": {
@@ -8977,12 +8977,12 @@
                             "value": "application/hal+json"
                         }
                     ],
-                    "body": "{\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"proident do sit sed dolor\"\n  }\n },\n \"_embedded\": {\n  \"publiekrechtelijkeBeperkingen\": [\n   {\n    \"identificatie\": \"qui sit\",\n    \"domein\": \"est ut n\",\n    \"grondslag\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"datumInWerking\": \"1957-06-07\",\n    \"datumBeeindiging\": \"2004-12-20\",\n    \"bevoegdGezag\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"isGebaseerdOpStukdeelIdentificatie\": \"exercitation tempor\",\n    \"isVermeldInStukdeelIdentificaties\": [\n     \"aliqua dolore\",\n     \"est\"\n    ],\n    \"_links\": {\n     \"bevoegdGezag\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"labori\"\n     },\n     \"isGebaseerdOpStukdeel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"in occaecat commodo\"\n     },\n     \"isVermeldInStukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   },\n   {\n    \"identificatie\": \"dolore ex proident do\",\n    \"domein\": \"dolore nulla est irure adipisicing\",\n    \"grondslag\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"datumInWerking\": \"1994-08-26\",\n    \"datumBeeindiging\": \"1956-05-07\",\n    \"bevoegdGezag\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"isGebaseerdOpStukdeelIdentificatie\": \"nulla Excepteur elit\",\n    \"isVermeldInStukdeelIdentificaties\": [\n     \"in\",\n     \"ipsum minim\"\n    ],\n    \"_links\": {\n     \"bevoegdGezag\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"elit laboris sed Duis mollit\"\n     },\n     \"isGebaseerdOpStukdeel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"eu est cillum consectetur elit\"\n     },\n     \"isVermeldInStukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   }\n  ]\n }\n}",
+                    "body": "{\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"deserunt dolore ullamco\"\n  }\n },\n \"_embedded\": {\n  \"publiekrechtelijkeBeperkingen\": [\n   {\n    \"identificatie\": \"l\",\n    \"domein\": \"tempor ea in\",\n    \"grondslag\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"datumInWerking\": \"1943-06-13\",\n    \"datumBeeindiging\": \"1966-01-05\",\n    \"bevoegdGezag\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"Stukken\": [\n     \"dolor esse enim minim\",\n     \"in occaecat aute\"\n    ],\n    \"isGebaseerdOpStukdeelIdentificatie\": \"fugiat culpa ex proident\",\n    \"isVermeldInStukdeelIdentificaties\": [\n     \"minim dolore\",\n     \"dolore\"\n    ],\n    \"_links\": {\n     \"bevoegdGezag\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"exercitation\"\n     },\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isGebaseerdOpStukdeel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"voluptate amet pariatur\"\n     },\n     \"isVermeldInStukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   },\n   {\n    \"identificatie\": \"culpa nulla quis\",\n    \"domein\": \"aliqua ad no\",\n    \"grondslag\": {\n     \"code\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     },\n     \"waarde\": {\n      \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n     }\n    },\n    \"datumInWerking\": \"1968-08-19\",\n    \"datumBeeindiging\": \"1949-12-28\",\n    \"bevoegdGezag\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"Stukken\": [\n     \"veniam esse sed\",\n     \"magna Excepteur tempor eiusmod\"\n    ],\n    \"isGebaseerdOpStukdeelIdentificatie\": \"nostrud proident irure\",\n    \"isVermeldInStukdeelIdentificaties\": [\n     \"ea laboris\",\n     \"non lab\"\n    ],\n    \"_links\": {\n     \"bevoegdGezag\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": false,\n      \"title\": \"ex dol\"\n     },\n     \"stukken\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ],\n     \"isGebaseerdOpStukdeel\": {\n      \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n      \"templated\": true,\n      \"title\": \"labore veniam ut deserunt\"\n     },\n     \"isVermeldInStukdelen\": [\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     ]\n    }\n   }\n  ]\n }\n}",
                     "cookie": [],
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "924ec2c1-300d-4c39-9cc4-4e248e39fa2a",
+                    "id": "686ec68a-a645-421b-a36c-75548c205964",
                     "name": "Bad Request",
                     "originalRequest": {
                         "url": {
@@ -9035,7 +9035,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "bbb4df67-663b-42fc-b713-3e1f1a0b25fa",
+                    "id": "c9541dbd-50f0-46a3-bbe1-7f2e15e904cc",
                     "name": "Unauthorized",
                     "originalRequest": {
                         "url": {
@@ -9088,7 +9088,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "ab01b8f4-7038-42b9-b27f-3b9e8d3a9eba",
+                    "id": "d8bb3238-9aa6-4fe0-9b10-2e73455543d5",
                     "name": "Forbidden",
                     "originalRequest": {
                         "url": {
@@ -9141,7 +9141,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "96f52c55-c1c1-4528-a4ff-39027a423138",
+                    "id": "555b1e55-0126-403e-a325-90e781a5fc34",
                     "name": "Not Acceptable",
                     "originalRequest": {
                         "url": {
@@ -9194,7 +9194,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "fbb1edc6-1308-4bc9-b0dd-68c90951cec4",
+                    "id": "3958d92f-7fc7-4daa-ac9f-186438477187",
                     "name": "Internal Server Error",
                     "originalRequest": {
                         "url": {
@@ -9247,7 +9247,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "ab56a718-5752-4dbc-8d61-356b623b8d8f",
+                    "id": "a7e4f4e3-f982-4ce9-a567-410698c18b39",
                     "name": "Service Unavailable",
                     "originalRequest": {
                         "url": {
@@ -9303,7 +9303,7 @@
             "event": []
         },
         {
-            "id": "38e60847-2d45-4f19-8423-ef839c794b1d",
+            "id": "cbf8eb85-3270-492a-a4d3-e461f9f2068d",
             "name": "Get Stuk",
             "request": {
                 "name": "Get Stuk",
@@ -9345,7 +9345,7 @@
             },
             "response": [
                 {
-                    "id": "33cd451f-6de8-493f-9f90-7ce35a873e7c",
+                    "id": "dcb082e0-bb69-4201-ba9e-2eb2f12c6148",
                     "name": "Zoekactie geslaagd\n",
                     "originalRequest": {
                         "url": {
@@ -9404,12 +9404,12 @@
                             "value": "application/hal+json"
                         }
                     ],
-                    "body": "{\n \"identificatie\": \"in dolore\",\n \"stukType\": \"Kadasterstuk\",\n \"domein\": \"consectetur amet officia\",\n \"toelichtingBewaarder\": \"nisi adipisicing consectetur laborum\",\n \"stukdeelIdentificaties\": [\n  \"enim ad elit Ut\",\n  \"cupidatat ut ipsum sunt\"\n ],\n \"bewaardersVerklaring\": \"fugiat in\",\n \"tekeningIngeschreven\": true,\n \"tijdstipAanbieding\": \"2006-11-28T22:09:57.431Z\",\n \"tijdstipOndertekening\": \"1955-01-02T06:34:08.019Z\",\n \"aard\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"status\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"equivalentieVerklaarder\": {\n  \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n },\n \"kadasterverzoeken\": [\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n ],\n \"oorspronkelijkStukIdentificatie\": \"sint Ut in\",\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"laboris ut\"\n  },\n  \"stukdelen\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ],\n  \"oorspronkelijkStuk\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"esse eu aute\"\n  }\n }\n}",
+                    "body": "{\n \"identificatie\": \"anim dolor minim\",\n \"stukType\": \"Aangebodenstuk\",\n \"domein\": \"anim\",\n \"toelichtingBewaarder\": \"et eiusmod quis\",\n \"stukdeelIdentificaties\": [\n  \"ullamco labore Ut\",\n  \"non ad velit\"\n ],\n \"bewaardersVerklaring\": \"adipisicin\",\n \"tekeningIngeschreven\": true,\n \"tijdstipAanbieding\": \"1992-03-12T10:13:22.988Z\",\n \"tijdstipOndertekening\": \"1966-10-20T19:03:53.422Z\",\n \"aard\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"status\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"equivalentieVerklaarder\": {\n  \"geslachtsnaam\": \"nisi\",\n  \"voornamen\": \"nisi\",\n  \"voorvoegsel\": \"enim voluptate id\",\n  \"standplaats\": \"dolor\"\n },\n \"kadasterverzoeken\": [\n  {\n   \"aard\": {\n    \"code\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"waarde\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    }\n   },\n   \"redenenVerzoek\": [\n    {\n     \"redenOmschrijving\": \"ullamco aliqua eu\",\n     \"reden\": {\n      \"code\": {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"waarde\": {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     }\n    },\n    {\n     \"redenOmschrijving\": \"vel\",\n     \"reden\": {\n      \"code\": {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"waarde\": {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     }\n    }\n   ]\n  },\n  {\n   \"aard\": {\n    \"code\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    },\n    \"waarde\": {\n     \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n    }\n   },\n   \"redenenVerzoek\": [\n    {\n     \"redenOmschrijving\": \"do dolor\",\n     \"reden\": {\n      \"code\": {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"waarde\": {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     }\n    },\n    {\n     \"redenOmschrijving\": \"labore ex irure\",\n     \"reden\": {\n      \"code\": {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      },\n      \"waarde\": {\n       \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n      }\n     }\n    }\n   ]\n  }\n ],\n \"oorspronkelijkStukIdentificatie\": \"velit sit in enim\",\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"ad ea amet do\"\n  },\n  \"stukdelen\": [\n   {\n    \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n    \"templated\": true,\n    \"title\": \"esse sunt et\"\n   },\n   {\n    \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n    \"templated\": true,\n    \"title\": \"nisi voluptate occaecat magna\"\n   }\n  ],\n  \"oorspronkelijkStuk\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"fugiat exe\"\n  }\n }\n}",
                     "cookie": [],
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "1ae60232-b767-4263-bd86-ebc590d46675",
+                    "id": "c7f2a398-4f6d-4753-be6e-e6ac0881f619",
                     "name": "Bad Request",
                     "originalRequest": {
                         "url": {
@@ -9468,7 +9468,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "a87b3b54-52dc-4195-8cb6-f6127fe4a577",
+                    "id": "8f709062-1302-43c6-a9a7-deb69c7d119a",
                     "name": "Unauthorized",
                     "originalRequest": {
                         "url": {
@@ -9527,7 +9527,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "cedadea0-4e5c-468c-9c0e-7fdee201fe89",
+                    "id": "fc172f20-f4de-4151-a14d-25bca40617d8",
                     "name": "Forbidden",
                     "originalRequest": {
                         "url": {
@@ -9586,7 +9586,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "e7afaa97-d3e0-4433-a189-696877190615",
+                    "id": "c6ec6003-6613-49d9-bc72-767ab4b72b5a",
                     "name": "Not Found",
                     "originalRequest": {
                         "url": {
@@ -9645,7 +9645,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "c11ac9c3-3bee-40c3-bf3f-7f5e08bb3c56",
+                    "id": "2281bd22-e1b5-4dd5-ad69-fb1856d18932",
                     "name": "Not Acceptable",
                     "originalRequest": {
                         "url": {
@@ -9704,7 +9704,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "7a9e1324-8121-4d24-8837-b423c04a7879",
+                    "id": "35fe8d3c-c441-4e1f-a319-664a23605bf3",
                     "name": "Gone",
                     "originalRequest": {
                         "url": {
@@ -9763,7 +9763,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "a9bb2658-842e-4eb2-b356-cef9d50e174c",
+                    "id": "24614320-8ca9-4ff0-98af-cf81e9644044",
                     "name": "Internal Server Error",
                     "originalRequest": {
                         "url": {
@@ -9822,7 +9822,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "9dd0bd51-3229-4915-add1-11f8b572ac3b",
+                    "id": "fb569bd9-8677-452a-8a0b-afee0073af79",
                     "name": "Service Unavailable",
                     "originalRequest": {
                         "url": {
@@ -9884,7 +9884,7 @@
             "event": []
         },
         {
-            "id": "224a99d4-5925-46ed-900b-415f9bdf4cc9",
+            "id": "5df58690-0fdc-4e6d-8fe0-dc388471b92b",
             "name": "Get Stukdeel",
             "request": {
                 "name": "Get Stukdeel",
@@ -9921,7 +9921,7 @@
             },
             "response": [
                 {
-                    "id": "259cd532-b8e1-4953-8163-5d73a2254207",
+                    "id": "6b5fbe9e-03d1-448a-8160-34da1c0cfed6",
                     "name": "Zoekactie geslaagd\n",
                     "originalRequest": {
                         "url": {
@@ -9976,12 +9976,12 @@
                             "value": "application/hal+json"
                         }
                     ],
-                    "body": "{\n \"identificatie\": \"eiusmod id sed ut dolore\",\n \"domein\": \"fugiat commodo dolore aute Excepteur\",\n \"aard\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"bedragTransactiesomLevering\": {\n  \"som\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"valuta\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"omschrijvingKadastraleObjecten\": \"in tempor et aute non\",\n \"omschrijvingTopografischeMutatie\": \"deserunt magna\",\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"sint in est Excepteur do\"\n  },\n  \"stuk\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": false,\n   \"title\": \"consequat\"\n  },\n  \"kadastraalOnroerendeZaken\": [\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   },\n   {\n    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n   }\n  ]\n }\n}",
+                    "body": "{\n \"identificatie\": \"non eiusmod dolore\",\n \"domein\": \"cillum nulla\",\n \"aard\": {\n  \"code\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"waarde\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"bedragTransactiesomLevering\": {\n  \"som\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  },\n  \"valuta\": {\n   \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n  }\n },\n \"omschrijvingKadastraleObjecten\": \"anim\",\n \"omschrijvingTopografischeMutatie\": \"sed laborum nostrud\",\n \"_links\": {\n  \"self\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"ut aliqua ipsum sed velit\"\n  },\n  \"stuk\": {\n   \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n   \"templated\": true,\n   \"title\": \"voluptate ipsum amet\"\n  },\n  \"kadastraalOnroerendeZaken\": [\n   {\n    \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n    \"templated\": true,\n    \"title\": \"aliqua laboris velit et culpa\"\n   },\n   {\n    \"href\": \"https://datapunt.voorbeeldgemeente.nl/api/v{major-versie}/resourcename/{resource-identificatie}\",\n    \"templated\": false,\n    \"title\": \"ut tempor qui\"\n   }\n  ]\n }\n}",
                     "cookie": [],
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "3e33d471-5898-4879-87f3-8e076d536b16",
+                    "id": "714aef3a-b2bd-408d-9dc2-16a2db88ed3a",
                     "name": "Bad Request",
                     "originalRequest": {
                         "url": {
@@ -10036,7 +10036,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "4aba37ef-bdc3-47d8-96c0-3331e0ac1ee1",
+                    "id": "e739ad86-cf0b-4394-9ac0-3a8ccfe24fc4",
                     "name": "Unauthorized",
                     "originalRequest": {
                         "url": {
@@ -10091,7 +10091,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "46dda268-4dfb-4678-af28-f307907aff67",
+                    "id": "0b3fcfc1-766f-4a5b-8535-8b0c09cedb09",
                     "name": "Forbidden",
                     "originalRequest": {
                         "url": {
@@ -10146,7 +10146,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "a8f70caf-f659-4343-af94-62ff7a9deca5",
+                    "id": "c2b19bdb-85b7-4d6d-b5c6-79fc0b75710a",
                     "name": "Not Found",
                     "originalRequest": {
                         "url": {
@@ -10201,7 +10201,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "cd0c26af-bbb7-4df9-868d-e46c1a0a7c59",
+                    "id": "955b2d75-92fb-4336-9763-122a939f9813",
                     "name": "Not Acceptable",
                     "originalRequest": {
                         "url": {
@@ -10256,7 +10256,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "55ace709-0c15-4cce-a91d-44f8356c0e68",
+                    "id": "bd4bbeed-8a72-4fcb-ad2f-959ef54f0314",
                     "name": "Gone",
                     "originalRequest": {
                         "url": {
@@ -10311,7 +10311,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "fb4b25ca-60d9-4304-89ba-b09cf5af66c1",
+                    "id": "14a93e4b-a83e-4218-b018-761f0bacd290",
                     "name": "Internal Server Error",
                     "originalRequest": {
                         "url": {
@@ -10366,7 +10366,7 @@
                     "_postman_previewlanguage": "json"
                 },
                 {
-                    "id": "2d8c1010-1d5e-49fd-9aff-985fd0fd62ca",
+                    "id": "bd626bce-2094-4356-bec6-02fe105384c5",
                     "name": "Service Unavailable",
                     "originalRequest": {
                         "url": {
@@ -10450,7 +10450,7 @@
         ]
     },
     "info": {
-        "_postman_id": "8bb601d4-d924-44bc-831a-6d1cf1d6dcdb",
+        "_postman_id": "b76ecf28-22bd-40ad-8f62-56a295385df7",
         "name": "Kadaster - BRK-Bevragen API",
         "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
         "description": {


### PR DESCRIPTION
- Probleem met HalLin_2 opgelost (was een verwijzing naar een oude "common"-versie 
- Stukken en stukdelen waren onterecht toegevoegd aan de zakelijkgerechtigdeHalCollectieEmbedded. --> Verwijderd
- ZakelijkGerechtigdeLinks --> isGebaseerOpStukdeel was een array. Nu een enkele link
- property Kadasterverzoek.Redenenverzoek --> Kadasterverzoek.redenenverzoek 
- PubliekrechtelijkeBeperkingen --> Stukidentificaties en link naar stukken (array) toegevoegd. Stukdelen nog laten staan.(Marcel zoekt dit uit) 
- Tag Stukdelen verwijderd
- Stuktype_enmum --> StuktypeEnum (Description volgt nog)
- Stuk.tekeningIngeschreven --> Stuk.indicatieTekeningBijgevoegd + description aangepast
- Descriptions omgezet naar markdown voor Stukken en Stukdelen
- Stukken uit KadastraalOnroerendeZaakEmbedded verwijderd.