### PR TITLE
correctie adresregel1 example

### DIFF
--- a/specificatie/domain.yaml
+++ b/specificatie/domain.yaml
@@ -87,7 +87,7 @@ components:
               description: |
                             Het eerste deel van een adres is een combinatie van de straat en huisnummer.
               # example: "1600 Pennsylvania Avenue NW"
-              example: "Laan van de landinrichtingscommissie Duiven-Westervoort 1A-bis"
+              example: "Ln vd l D-Westervoort 1A-bis"
             adresregel2:
               type: "string"
               description: |

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -5353,7 +5353,7 @@
             "adresregel1" : {
               "type" : "string",
               "description" : "Het eerste deel van een adres is een combinatie van de straat en huisnummer.\n",
-              "example" : "Laan van de landinrichtingscommissie Duiven-Westervoort 1A-bis"
+              "example" : "Ln vd l D-Westervoort 1A-bis"
             },
             "adresregel2" : {
               "type" : "string",

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -4193,7 +4193,7 @@ components:
             type: string
             description: |
               Het eerste deel van een adres is een combinatie van de straat en huisnummer.
-            example: Laan van de landinrichtingscommissie Duiven-Westervoort 1A-bis
+            example: Ln vd l D-Westervoort 1A-bis
           adresregel2:
             type: string
             description: |


### PR DESCRIPTION
het voorbeeld gebruikt de straatnaam. Dat is niet correct, want moet de korteNaam gebruiken. Anders past het niet op een envelop of binnen een envelopvenster