### PR TITLE
Toevoegen erfpachtersDoorAppartementsrechtSplitsing

### DIFF
--- a/specificatie/domain.yaml
+++ b/specificatie/domain.yaml
@@ -251,7 +251,7 @@ components:
               type: "string"
               description: |
                             Adres of standplaats/plaats van vestiging van de ondertekenaar.
-    ErfpachtersDoorAppartementsrechtsplitsing:
+    ErfpachtersDoorAppartementsrechtSplitsing:
       type: "object"
       description: |
                     De identificaties van de eigenaren van de appartementsrechten die uit erfpacht ontstaan zijn.

--- a/specificatie/domain.yaml
+++ b/specificatie/domain.yaml
@@ -251,15 +251,6 @@ components:
               type: "string"
               description: |
                             Adres of standplaats/plaats van vestiging van de ondertekenaar.
-    ErfpachtersDoorAppartementsrechtSplitsing:
-      type: "object"
-      description: |
-                    De identificaties van de eigenaren van de appartementsrechten die uit erfpacht ontstaan zijn.
-      properties:
-        kadastraalOnroerendeZaakIdentificatie:
-          type: string
-        zakelijkGerechtigdeIdentificatie:
-          type: string
     Filiatie:
       type: "object"
       properties:
@@ -577,12 +568,6 @@ components:
           type : "array"
           items:
             type: "string"
-        erfpachtersDoorAppartementsrechtSplitsing:
-          description: |
-                      De eigenaren van de appartementsrechten die uit erfpacht zijn ontstaan
-          type : "array"
-          items:
-            $ref: "#/components/schemas/ErfpachtersDoorAppartementsrechtSplitsing"
         isVermeldInStukdeelIdentificaties:
           type: "array"
           items:

--- a/specificatie/domain.yaml
+++ b/specificatie/domain.yaml
@@ -251,6 +251,15 @@ components:
               type: "string"
               description: |
                             Adres of standplaats/plaats van vestiging van de ondertekenaar.
+    ErfpachtersDoorAppartementsrechtsplitsing:
+      type: "object"
+      description: |
+                    De identificaties van de eigenaren van de appartementsrechten die uit erfpacht ontstaan zijn.
+      properties:
+        kadastraalOnroerendeZaakIdentificatie:
+          type: string
+        zakelijkGerechtigdeIdentificatie:
+          type: string
     Filiatie:
       type: "object"
       properties:
@@ -568,6 +577,12 @@ components:
           type : "array"
           items:
             type: "string"
+        erfpachtersDoorAppartementsrechtSplitsing:
+          description: |
+                      De eigenaren van de appartementsrechten die uit erfpacht zijn ontstaan
+          type : "array"
+          items:
+            $ref: "#/components/schemas/ErfpachtersDoorAppartementsrechtSplitsing"
         isVermeldInStukdeelIdentificaties:
           type: "array"
           items:

--- a/specificatie/genereervariant/openapi.json
+++ b/specificatie/genereervariant/openapi.json
@@ -4355,6 +4355,7 @@
           },
           "andereErfpachters" : {
             "type" : "array",
+            "description" : "De eigenaren van de appartementsrechten die uit erfpacht zijn ontstaan\n",
             "items" : {
               "$ref" : "#/components/schemas/ZakelijkGerechtigdeHal"
             }

--- a/specificatie/genereervariant/openapi.yaml
+++ b/specificatie/genereervariant/openapi.yaml
@@ -3428,6 +3428,8 @@ components:
             $ref: '#/components/schemas/ZakelijkGerechtigdeHal'
         andereErfpachters:
           type: array
+          description: |
+            De eigenaren van de appartementsrechten die uit erfpacht zijn ontstaan
           items:
             $ref: '#/components/schemas/ZakelijkGerechtigdeHal'
         privaatrechtelijkeBeperkingen:

--- a/specificatie/kadastraal-onroerende-zaken.yaml
+++ b/specificatie/kadastraal-onroerende-zaken.yaml
@@ -275,6 +275,10 @@ components:
           type: "array"
           items:
             $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+        erfpachtersDoorAppartementsrechtSplitsing:
+          type: "array"
+          items:
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalLink"
     KadastraalOnroerendeZaakEmbedded:
       type: "object"
       properties:

--- a/specificatie/kadastraal-onroerende-zaken.yaml
+++ b/specificatie/kadastraal-onroerende-zaken.yaml
@@ -275,14 +275,14 @@ components:
           type: "array"
           items:
             $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
-        erfpachtersDoorAppartementsrechtSplitsing:
-          type: "array"
-          items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.3.0/api-specificatie/common.yaml#/components/schemas/HalLink"
     KadastraalOnroerendeZaakEmbedded:
       type: "object"
       properties:
         zakelijkGerechtigden:
+          type: "array"
+          items:
+            $ref: "zakelijk-gerechtigden.yaml#/components/schemas/ZakelijkGerechtigdeHal"
+        andereErfpachters:
           type: "array"
           items:
             $ref: "zakelijk-gerechtigden.yaml#/components/schemas/ZakelijkGerechtigdeHal"

--- a/specificatie/kadastraal-onroerende-zaken.yaml
+++ b/specificatie/kadastraal-onroerende-zaken.yaml
@@ -284,6 +284,8 @@ components:
             $ref: "zakelijk-gerechtigden.yaml#/components/schemas/ZakelijkGerechtigdeHal"
         andereErfpachters:
           type: "array"
+          description: |
+                        De eigenaren van de appartementsrechten die uit erfpacht zijn ontstaan
           items:
             $ref: "zakelijk-gerechtigden.yaml#/components/schemas/ZakelijkGerechtigdeHal"
         privaatrechtelijkeBeperkingen:


### PR DESCRIPTION
Na HC-overleg is de property erfpachtersDoorAppartementsrechtSplitsing weer verwijderd uit de kadastraalOnroerendeZaak en uit de kadastraalOnroerendeZaakLinks en is  "andereErfpachters" toegevoegd aan kadastraalOnroerendeZaakEmbedded. Argument is dat als je deze andere erfpachters op wilt halen je ze altijd allemaal op wilt halen. 