### PR TITLE
appartementsrechtVolgnummer toevoegen aan bijbehorendeAppartementsrechten

### DIFF
--- a/specificatie/domain.yaml
+++ b/specificatie/domain.yaml
@@ -203,7 +203,7 @@ components:
                         De identificaties van de stukdelen (paragrafen in een akte met een rechtsfeit) waarin dit beslag is vermeld
           items:
             type: "string"
-    BijbehorendeAppartementsrechten:
+    BijbehorendAppartementsrecht:
       type: "object"
       description: |
                     De appartementsrechten die bij deze KadastraalOnroerende Zaak (grondperceel) horen
@@ -578,7 +578,7 @@ components:
                       De verwijzingen naar de actuele appartementsrechten die bij deze KadastraalOnroerende Zaak (grondperceel) horen
           type : "array"
           items:
-            $ref: "#/components/schemas/BijbehorendeAppartementsrechten"
+            $ref: "#/components/schemas/BijbehorendAppartementsrecht"
         isVermeldInStukdeelIdentificaties:
           type: "array"
           items:
@@ -600,7 +600,7 @@ components:
       properties:
         identificatie:
           description: |
-                        De identificatie(s) van de Kadastraal Onroerende Za(a)k(en).
+                        De identificaties van de Kadastraal Onroerende Za(a)k(en).
           type: "string"
         indicatieVervallen:
           description: |

--- a/specificatie/domain.yaml
+++ b/specificatie/domain.yaml
@@ -264,14 +264,8 @@ components:
       properties:
         aard:
           $ref: "#/components/schemas/Waardelijst"
-        kadastraalOnroerendeZaakIdentificatie:
-          description: |
-                        De identificatie(s) van de Kadastraal Onroerende Za(a)k(en).
-          type: "string"
-        indicatieVervallenKadastraalOnroerendeZaak:
-          description: |
-                        Geeft aan of de filiatie verwijst naar een vervallen kadastraal onroerende zaak.
-          type: "boolean"
+        kadastraalOnroerendeZaak:
+          $ref: "#/components/schemas/KadastraalOnroerendeZaakFiliatie"
     Geboorte:
       type: "object"
       description: |
@@ -590,6 +584,21 @@ components:
                         Dit kan een aangeboden stuk of een kadasterstuk zijn.
           items:
             type: string
+    KadastraalOroerendeZaakFiliatie:
+      type: "object"
+      description: |
+                    De eigenschappen van de kadastraalOnroerendeZaak die gerelateerd is.
+      properties:
+        identificatie:
+          description: |
+                        De identificatie(s) van de Kadastraal Onroerende Za(a)k(en).
+          type: "string"
+        indicatieVervallen:
+          description: |
+                        Geeft aan of de er verwezen wordt een vervallen kadastraal onroerende zaak.
+          type: "boolean"
+        appartementsrechtVolgnummer:
+          type: "string"
     Kadasterverzoek:
       type: "object"
       description: |

--- a/specificatie/domain.yaml
+++ b/specificatie/domain.yaml
@@ -203,6 +203,15 @@ components:
                         De identificaties van de stukdelen (paragrafen in een akte met een rechtsfeit) waarin dit beslag is vermeld
           items:
             type: "string"
+    BijbehorendeAppartementsrechten:
+      type: "object"
+      description: |
+                    De appartementsrechten die bij deze KadastraalOnroerende Zaak (grondperceel) horen
+      properties:
+        kadastraalOnroerendeZaakIdentificatie:
+          type: "string"
+        appartementsrechtVolgnummer:
+          type: "string"
     ErfpachtCanon:
       type: "object"
       description: |
@@ -564,12 +573,12 @@ components:
           type: "array"
           items:
             type: "string"
-        bijbehorendeAppartementsrechtIdentificaties:
+        bijbehorendeAppartementsrechten:
           description: |
-                      De kadstraalOnroerendeZaakidentificaties van de actuele appartementsrechten die bij deze KadastraalOnroerende Zaak (grondperceel) horen
+                      De verwijzingen naar de actuele appartementsrechten die bij deze KadastraalOnroerende Zaak (grondperceel) horen
           type : "array"
           items:
-            type: "string"
+            $ref: "#/components/schemas/BijbehorendeAppartementsrechten"
         isVermeldInStukdeelIdentificaties:
           type: "array"
           items:
@@ -584,7 +593,7 @@ components:
                         Dit kan een aangeboden stuk of een kadasterstuk zijn.
           items:
             type: string
-    KadastraalOroerendeZaakFiliatie:
+    KadastraalOnroerendeZaakFiliatie:
       type: "object"
       description: |
                     De eigenschappen van de kadastraalOnroerendeZaak die gerelateerd is.

--- a/specificatie/domain.yaml
+++ b/specificatie/domain.yaml
@@ -600,14 +600,12 @@ components:
       properties:
         identificatie:
           description: |
-                        De identificaties van de Kadastraal Onroerende Za(a)k(en).
+                        De identificatie van de Kadastraal Onroerende Zaak.
           type: "string"
         indicatieVervallen:
           description: |
                         Geeft aan of de er verwezen wordt een vervallen kadastraal onroerende zaak.
           type: "boolean"
-        appartementsrechtVolgnummer:
-          type: "string"
     Kadasterverzoek:
       type: "object"
       description: |


### PR DESCRIPTION
zie #843  

in bijbehorendeAppartementsrechten wordt appartementsrechtVolgnummer toegevoegd, zodat direct duidelijk is welke appartementen het betreft en dit in een overzicht (client) getoond kan worden.