### PR TITLE
filiatie feature toegevoegd

### DIFF
--- a/features/filiatie.feature
+++ b/features/filiatie.feature
@@ -4,77 +4,12 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
 
     #TODO: invullen onroerende zaak identificaties
 
-    Achtergrond:
-        Gegeven Perceel met identificatie "P1" is gesplitst naar percelen "P2" en "P3"
-        En Perceel met identificatie "P1" is niet ontstaan uit splitsing of vereniging van een ander perceel
-        En Perceel met identificatie "P2" is niet verder gesplitst of verenigd
-        En Perceel met identificatie "P3" is niet verder gesplitst of verenigd
-
-        En Percelen met identificatie "P4" en "P5" zijn verenigd naar perceel "P6"
-        En Perceel met identificatie "P4" is niet ontstaan uit splitsing of vereniging van een ander perceel
-        En Perceel met identificatie "P5" is niet ontstaan uit splitsing of vereniging van een ander perceel
-        En Perceel met identificatie "P6" is niet verder gesplitst of verenigd
-
-        En Perceel met identificatie "P7" is gesplitst naar appartementsrechten "A1" en "A2"
-        En Perceel met identificatie "P7" is niet ontstaan uit splitsing of vereniging van een ander perceel
-        En Appartementsrecht met identificatie "A1" is niet verder gesplitst of verenigd
-        En Appartementsrecht met identificatie "A1" heeft "appartementsrechtVolgnummer"= 1
-        En Appartementsrecht met identificatie "A2" is niet verder gesplitst of verenigd
-        En Appartementsrecht met identificatie "A2" heeft "appartementsrechtVolgnummer"= 2
-
-        En Percelen met identificatie "P8" en "P9" zijn gesplitst naar appartementsrechten "A3" en "A4"
-        En Perceel met identificatie "P8" is niet ontstaan uit splitsing of vereniging van een ander perceel
-        En Perceel met identificatie "P9" is niet ontstaan uit splitsing of vereniging van een ander perceel
-        En Appartementsrecht met identificatie "A3" is niet verder gesplitst of verenigd
-        En Appartementsrecht met identificatie "A3" heeft "appartementsrechtVolgnummer"= 1
-        En Appartementsrecht met identificatie "A4" is niet verder gesplitst of verenigd
-        En Appartementsrecht met identificatie "A4" heeft "appartementsrechtVolgnummer"= 2
-
-        En Perceel met identificatie "P10" is gesplitst naar appartementsrechten "A5" en "A6"
-        En Perceel met identificatie "P10" is niet ontstaan uit splitsing of vereniging van een ander perceel
-        En Appartementsrecht met identificatie "A5" is niet verder gesplitst of verenigd
-        En Appartementsrecht met identificatie "A5" heeft "appartementsrechtVolgnummer"= 1
-        En Appartementsrecht met identificatie "A6" is ondergesplitst in appartementsrechten "A7" en "A8"
-        En Appartementsrecht met identificatie "A6" heeft "appartementsrechtVolgnummer"= 2
-        En Appartementsrecht met identificatie "A7" heeft "appartementsrechtVolgnummer"= 3
-        En Appartementsrecht met identificatie "A8" heeft "appartementsrechtVolgnummer"= 4
-
-        En Perceel met identificatie "P11" is gesplitst naar percelen "P12" en "P13"
-        En Perceel met identificatie "P12" is gesplitst naar appartementsrechten "A9" en "A10"
-        En Appartementsrecht met identificatie "A9" is niet verder gesplitst of verenigd
-        En Appartementsrecht met identificatie "A9" heeft "appartementsrechtVolgnummer"= 1
-        En Appartementsrecht met identificatie "A10" is niet verder gesplitst of verenigd
-        En Appartementsrecht met identificatie "A10" heeft "appartementsrechtVolgnummer"= 2
-
-        En Percelen met identificatie "P14" en "P15" zijn verenigd naar perceel "P16"
-        En Perceel met identificatie "P16" is gesplitst naar appartementsrechten "A11" en "A12"
-        En Appartementsrecht met identificatie "A11" is niet verder gesplitst of verenigd
-        En Appartementsrecht met identificatie "A11" heeft "appartementsrechtVolgnummer"= 1
-        En Appartementsrecht met identificatie "A12" is niet verder gesplitst of verenigd
-        En Appartementsrecht met identificatie "A12" heeft "appartementsrechtVolgnummer"= 2
-
-        En Perceel met identificatie "P17" is gesplitst naar appartementsrechten "A13", "A14" en "A15"
-        En Perceel met identificatie "P17" is niet ontstaan uit splitsing of vereniging van een ander perceel
-        En Appartementsrecht met identificatie "A13" is niet verder gesplitst of verenigd
-        En Appartementsrecht met identificatie "A14" is ondergesplitst in appartementsrechten "A16" en "A17"
-        En Appertementsrechten met identificatie "A15" en "A17" zijn samengevoegd (via wijzigingssplitsing)
-        En voor de wijzigingssplitsing zijn appartementsrechten "A13", "A14", "A15", "A16" en "A17" vervallen
-        En is appartementsrecht "A13" nieuw appartementsrecht "A18" geworden
-        En is appartementsrecht "A16" nieuw appartementsrecht "A19" geworden
-        En zijn appartementsrechten "A15" en "A17" nieuw appartementsrecht "A20" geworden
-        En Appartementsrecht met identificatie "A13" heeft "appartementsrechtVolgnummer"= 1
-        En Appartementsrecht met identificatie "A14" heeft "appartementsrechtVolgnummer"= 2
-        En Appartementsrecht met identificatie "A15" heeft "appartementsrechtVolgnummer"= 3
-        En Appartementsrecht met identificatie "A16" heeft "appartementsrechtVolgnummer"= 4
-        En Appartementsrecht met identificatie "A17" heeft "appartementsrechtVolgnummer"= 5
-        En Appartementsrecht met identificatie "A18" heeft "appartementsrechtVolgnummer"= 6
-        En Appartementsrecht met identificatie "A19" heeft "appartementsrechtVolgnummer"= 6
-        En Appartementsrecht met identificatie "A20" heeft "appartementsrechtVolgnummer"= 6
-        En Appartementsrecht met identificatie "A18" is niet verder gesplitst of verenigd
-
-
-    Rule: Na splitsing van een perceel wordt filiatie getoond bij het vervallen perceel en bij de nieuwe percelen
+    Rule: Na splitsing van een perceel wordt filiatie opgenomen bij het vervallen perceel en bij de nieuwe percelen
         Scenario: Opvragen van een vervallen perceel na splitsing
+            Gegeven Perceel met identificatie "P1" is gesplitst naar percelen "P2" en "P3"
+            En Perceel met identificatie "P1" is niet ontstaan uit splitsing of vereniging van een ander perceel
+            En Perceel met identificatie "P2" is niet verder gesplitst of verenigd
+            En Perceel met identificatie "P3" is niet verder gesplitst of verenigd
             Als "/kadastraalonroerendezaken/P1" wordt gevraagd
             Dan bevat het antwoord "isOvergegaanIn" met waarde:    
                 """
@@ -124,6 +59,10 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
     
     Rule: Na vereniging van percelen wordt filiatie getoond bij de vervallen percelen en bij het nieuwe perceel
         Scenario: Opvragen vervallen perceel na vereniging
+            Gegeven Percelen met identificatie "P4" en "P5" zijn verenigd naar perceel "P6"
+            En Perceel met identificatie "P4" is niet ontstaan uit splitsing of vereniging van een ander perceel
+            En Perceel met identificatie "P5" is niet ontstaan uit splitsing of vereniging van een ander perceel
+            En Perceel met identificatie "P6" is niet verder gesplitst of verenigd
             Als "/kadastraalonroerendezaken/P4" wordt gevraagd
             Dan bevat het antwoord "isOvergegaanIn" met waarde:    
                 """
@@ -144,6 +83,10 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
 
         Scenario: Opvragen perceel uit vereniging
+            Gegeven Percelen met identificatie "P4" en "P5" zijn verenigd naar perceel "P6"
+            En Perceel met identificatie "P4" is niet ontstaan uit splitsing of vereniging van een ander perceel
+            En Perceel met identificatie "P5" is niet ontstaan uit splitsing of vereniging van een ander perceel
+            En Perceel met identificatie "P6" is niet verder gesplitst of verenigd
             Als "/kadastraalonroerendezaken/P6" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
@@ -173,6 +116,12 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
 
     Rule: Splitsing in appartementsrechten van een perceel toont verwijzingen van het grondperceel naar de appartementsrechten en vice versa
         Scenario: Opvragen van het grondperceel na splitsing in appartementsrechten
+            Gegeven Perceel met identificatie "P7" is gesplitst naar appartementsrechten "A1" en "A2"
+            En Perceel met identificatie "P7" is niet ontstaan uit splitsing of vereniging van een ander perceel
+            En Appartementsrecht met identificatie "A1" is niet verder gesplitst of verenigd
+            En Appartementsrecht met identificatie "A1" heeft "appartementsrechtVolgnummer"= 1
+            En Appartementsrecht met identificatie "A2" is niet verder gesplitst of verenigd
+            En Appartementsrecht met identificatie "A2" heeft "appartementsrechtVolgnummer"= 2
             Als "/kadastraalonroerendezaken/P7" wordt gevraagd
             Dan bevat het antwoord "isOvergegaanIn" met waarde:    
                 """
@@ -205,6 +154,12 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             En bevat het antwoord geen property "bijbehorendeGrondperceelIdentificaties"
 
         Scenario: Opvragen appartementsrecht uit splitsing
+            Gegeven Perceel met identificatie "P7" is gesplitst naar appartementsrechten "A1" en "A2"
+            En Perceel met identificatie "P7" is niet ontstaan uit splitsing of vereniging van een ander perceel
+            En Appartementsrecht met identificatie "A1" is niet verder gesplitst of verenigd
+            En Appartementsrecht met identificatie "A1" heeft "appartementsrechtVolgnummer"= 1
+            En Appartementsrecht met identificatie "A2" is niet verder gesplitst of verenigd
+            En Appartementsrecht met identificatie "A2" heeft "appartementsrechtVolgnummer"= 2
             Als "/kadastraalonroerendezaken/A1" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
@@ -223,6 +178,13 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
 
         Scenario: Opvragen appartementsrecht met meerdere bijbehorende grondpercelen
+            Gegeven Percelen met identificatie "P8" en "P9" zijn gesplitst naar appartementsrechten "A3" en "A4"
+            En Perceel met identificatie "P8" is niet ontstaan uit splitsing of vereniging van een ander perceel
+            En Perceel met identificatie "P9" is niet ontstaan uit splitsing of vereniging van een ander perceel
+            En Appartementsrecht met identificatie "A3" is niet verder gesplitst of verenigd
+            En Appartementsrecht met identificatie "A3" heeft "appartementsrechtVolgnummer"= 1
+            En Appartementsrecht met identificatie "A4" is niet verder gesplitst of verenigd
+            En Appartementsrecht met identificatie "A4" heeft "appartementsrechtVolgnummer"= 2
             Als "/kadastraalonroerendezaken/A3" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
@@ -245,8 +207,16 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
 
     Rule: Bij ondersplitsing van een appartementsrecht worden alle bijbehorende appartementsrechten getoond bij het perceel en wordt indicatieSluimerend getoond bij het sluimerende appartementsrecht
         Scenario: Opvragen van het grondperceel na splitsing in appartementsrechten en ondersplitsing van een appartementsrecht
+            Gegeven Perceel met identificatie "P10" is gesplitst naar appartementsrechten "A5" en "A6"
+            En Perceel met identificatie "P10" is niet ontstaan uit splitsing of vereniging van een ander perceel
+            En Appartementsrecht met identificatie "A5" is niet verder gesplitst of verenigd
+            En Appartementsrecht met identificatie "A5" heeft "appartementsrechtVolgnummer"= 1
+            En Appartementsrecht met identificatie "A6" is ondergesplitst in appartementsrechten "A7" en "A8"
+            En Appartementsrecht met identificatie "A6" heeft "appartementsrechtVolgnummer"= 2
+            En Appartementsrecht met identificatie "A7" heeft "appartementsrechtVolgnummer"= 3
+            En Appartementsrecht met identificatie "A8" heeft "appartementsrechtVolgnummer"= 4
             Als "/kadastraalonroerendezaken/P10" wordt gevraagd
-            Dan bevat het antwoord "isOvergegaanIn" met waarde:    
+            Dan bevat het antwoord "isOvergegaanIn" met waarde:
                 """
                 [
                     {
@@ -287,6 +257,14 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
 
     Rule: Na ondersplitsing van een appartementsrecht toont de filiatie één stap omhoog of omlaag, plus het bijbehorende grondperceel
         Scenario: Opvragen sluimerend appartementsrecht na ondersplitsing
+            Gegeven Perceel met identificatie "P10" is gesplitst naar appartementsrechten "A5" en "A6"
+            En Perceel met identificatie "P10" is niet ontstaan uit splitsing of vereniging van een ander perceel
+            En Appartementsrecht met identificatie "A5" is niet verder gesplitst of verenigd
+            En Appartementsrecht met identificatie "A5" heeft "appartementsrechtVolgnummer"= 1
+            En Appartementsrecht met identificatie "A6" is ondergesplitst in appartementsrechten "A7" en "A8"
+            En Appartementsrecht met identificatie "A6" heeft "appartementsrechtVolgnummer"= 2
+            En Appartementsrecht met identificatie "A7" heeft "appartementsrechtVolgnummer"= 3
+            En Appartementsrecht met identificatie "A8" heeft "appartementsrechtVolgnummer"= 4
             Als "/kadastraalonroerendezaken/A6" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
@@ -315,6 +293,14 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
 
         Scenario: Opvragen appartementsrecht uit ondersplitsing
+            Gegeven Perceel met identificatie "P10" is gesplitst naar appartementsrechten "A5" en "A6"
+            En Perceel met identificatie "P10" is niet ontstaan uit splitsing of vereniging van een ander perceel
+            En Appartementsrecht met identificatie "A5" is niet verder gesplitst of verenigd
+            En Appartementsrecht met identificatie "A5" heeft "appartementsrechtVolgnummer"= 1
+            En Appartementsrecht met identificatie "A6" is ondergesplitst in appartementsrechten "A7" en "A8"
+            En Appartementsrecht met identificatie "A6" heeft "appartementsrechtVolgnummer"= 2
+            En Appartementsrecht met identificatie "A7" heeft "appartementsrechtVolgnummer"= 3
+            En Appartementsrecht met identificatie "A8" heeft "appartementsrechtVolgnummer"= 4
             Als "/kadastraalonroerendezaken/A7" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
@@ -334,6 +320,12 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
 
     Rule: Een vervallen (verenigd of gesplitst) perceel wordt niet getoond als bijbehorend grondperceel 
         Scenario: Opvragen appartementsrecht met grondperceel uit splitsing
+            Gegeven Perceel met identificatie "P11" is gesplitst naar percelen "P12" en "P13"
+            En Perceel met identificatie "P12" is gesplitst naar appartementsrechten "A9" en "A10"
+            En Appartementsrecht met identificatie "A9" is niet verder gesplitst of verenigd
+            En Appartementsrecht met identificatie "A9" heeft "appartementsrechtVolgnummer"= 1
+            En Appartementsrecht met identificatie "A10" is niet verder gesplitst of verenigd
+            En Appartementsrecht met identificatie "A10" heeft "appartementsrechtVolgnummer"= 2
             Als "/kadastraalonroerendezaken/A9" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
@@ -354,6 +346,12 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
 
         Scenario: Opvragen appartementsrecht met grondperceel uit vereniging
+            Gegeven Percelen met identificatie "P14" en "P15" zijn verenigd naar perceel "P16"
+            En Perceel met identificatie "P16" is gesplitst naar appartementsrechten "A11" en "A12"
+            En Appartementsrecht met identificatie "A11" is niet verder gesplitst of verenigd
+            En Appartementsrecht met identificatie "A11" heeft "appartementsrechtVolgnummer"= 1
+            En Appartementsrecht met identificatie "A12" is niet verder gesplitst of verenigd
+            En Appartementsrecht met identificatie "A12" heeft "appartementsrechtVolgnummer"= 2
             Als "/kadastraalonroerendezaken/A11" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
@@ -375,6 +373,24 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
     
     Rule: Na een wijzigingssplitsing van een appartementsrecht worden de vervallen appartementsrechten niet getoond en wordt de filiatie uit het oude appartementsrecht overgenomen in de nieuwe appartementsrechten
         Scenario: Opvragen van het grondperceel na wijzigingssplitsing van appartementsrechten
+            Gegeven Perceel met identificatie "P17" is gesplitst naar appartementsrechten "A13", "A14" en "A15"
+            En Perceel met identificatie "P17" is niet ontstaan uit splitsing of vereniging van een ander perceel
+            En Appartementsrecht met identificatie "A13" is niet verder gesplitst of verenigd
+            En Appartementsrecht met identificatie "A14" is ondergesplitst in appartementsrechten "A16" en "A17"
+            En Appertementsrechten met identificatie "A15" en "A17" zijn samengevoegd (via wijzigingssplitsing)
+            En voor de wijzigingssplitsing zijn appartementsrechten "A13", "A14", "A15", "A16" en "A17" vervallen
+            En is appartementsrecht "A13" nieuw appartementsrecht "A18" geworden
+            En is appartementsrecht "A16" nieuw appartementsrecht "A19" geworden
+            En zijn appartementsrechten "A15" en "A17" nieuw appartementsrecht "A20" geworden
+            En Appartementsrecht met identificatie "A13" heeft "appartementsrechtVolgnummer"= 1
+            En Appartementsrecht met identificatie "A14" heeft "appartementsrechtVolgnummer"= 2
+            En Appartementsrecht met identificatie "A15" heeft "appartementsrechtVolgnummer"= 3
+            En Appartementsrecht met identificatie "A16" heeft "appartementsrechtVolgnummer"= 4
+            En Appartementsrecht met identificatie "A17" heeft "appartementsrechtVolgnummer"= 5
+            En Appartementsrecht met identificatie "A18" heeft "appartementsrechtVolgnummer"= 6
+            En Appartementsrecht met identificatie "A19" heeft "appartementsrechtVolgnummer"= 6
+            En Appartementsrecht met identificatie "A20" heeft "appartementsrechtVolgnummer"= 6
+            En Appartementsrecht met identificatie "A18" is niet verder gesplitst of verenigd
             Als "/kadastraalonroerendezaken/P17" wordt gevraagd
             Dan bevat het antwoord "isOvergegaanIn" met waarde:    
                 """
@@ -419,11 +435,47 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             En bevat het antwoord geen property "bijbehorendeGrondperceelIdentificaties"
 
         Scenario: Opvragen van een vervallen appartementsrecht
+            Gegeven Perceel met identificatie "P17" is gesplitst naar appartementsrechten "A13", "A14" en "A15"
+            En Perceel met identificatie "P17" is niet ontstaan uit splitsing of vereniging van een ander perceel
+            En Appartementsrecht met identificatie "A13" is niet verder gesplitst of verenigd
+            En Appartementsrecht met identificatie "A14" is ondergesplitst in appartementsrechten "A16" en "A17"
+            En Appertementsrechten met identificatie "A15" en "A17" zijn samengevoegd (via wijzigingssplitsing)
+            En voor de wijzigingssplitsing zijn appartementsrechten "A13", "A14", "A15", "A16" en "A17" vervallen
+            En is appartementsrecht "A13" nieuw appartementsrecht "A18" geworden
+            En is appartementsrecht "A16" nieuw appartementsrecht "A19" geworden
+            En zijn appartementsrechten "A15" en "A17" nieuw appartementsrecht "A20" geworden
+            En Appartementsrecht met identificatie "A13" heeft "appartementsrechtVolgnummer"= 1
+            En Appartementsrecht met identificatie "A14" heeft "appartementsrechtVolgnummer"= 2
+            En Appartementsrecht met identificatie "A15" heeft "appartementsrechtVolgnummer"= 3
+            En Appartementsrecht met identificatie "A16" heeft "appartementsrechtVolgnummer"= 4
+            En Appartementsrecht met identificatie "A17" heeft "appartementsrechtVolgnummer"= 5
+            En Appartementsrecht met identificatie "A18" heeft "appartementsrechtVolgnummer"= 6
+            En Appartementsrecht met identificatie "A19" heeft "appartementsrechtVolgnummer"= 6
+            En Appartementsrecht met identificatie "A20" heeft "appartementsrechtVolgnummer"= 6
+            En Appartementsrecht met identificatie "A18" is niet verder gesplitst of verenigd
             Als "/kadastraalonroerendezaken/A15" wordt gevraagd
             Dan geeft het antwoord http statuscode 410
             En bevat het antwoord "detail": "Dit appartementsrecht is vervallen en is overgegaan in appartementsrecht A18"
 
         Scenario: opvragen van appartementsrecht na wijzigingssplitsing
+            Gegeven Perceel met identificatie "P17" is gesplitst naar appartementsrechten "A13", "A14" en "A15"
+            En Perceel met identificatie "P17" is niet ontstaan uit splitsing of vereniging van een ander perceel
+            En Appartementsrecht met identificatie "A13" is niet verder gesplitst of verenigd
+            En Appartementsrecht met identificatie "A14" is ondergesplitst in appartementsrechten "A16" en "A17"
+            En Appertementsrechten met identificatie "A15" en "A17" zijn samengevoegd (via wijzigingssplitsing)
+            En voor de wijzigingssplitsing zijn appartementsrechten "A13", "A14", "A15", "A16" en "A17" vervallen
+            En is appartementsrecht "A13" nieuw appartementsrecht "A18" geworden
+            En is appartementsrecht "A16" nieuw appartementsrecht "A19" geworden
+            En zijn appartementsrechten "A15" en "A17" nieuw appartementsrecht "A20" geworden
+            En Appartementsrecht met identificatie "A13" heeft "appartementsrechtVolgnummer"= 1
+            En Appartementsrecht met identificatie "A14" heeft "appartementsrechtVolgnummer"= 2
+            En Appartementsrecht met identificatie "A15" heeft "appartementsrechtVolgnummer"= 3
+            En Appartementsrecht met identificatie "A16" heeft "appartementsrechtVolgnummer"= 4
+            En Appartementsrecht met identificatie "A17" heeft "appartementsrechtVolgnummer"= 5
+            En Appartementsrecht met identificatie "A18" heeft "appartementsrechtVolgnummer"= 6
+            En Appartementsrecht met identificatie "A19" heeft "appartementsrechtVolgnummer"= 6
+            En Appartementsrecht met identificatie "A20" heeft "appartementsrechtVolgnummer"= 6
+            En Appartementsrecht met identificatie "A18" is niet verder gesplitst of verenigd
             Als "/kadastraalonroerendezaken/A18" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
@@ -445,6 +497,24 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
 
         Scenario: opvragen van sluimerend appartementsrecht na wijzigingssplitsing in gesplitst perceel
+            Gegeven Perceel met identificatie "P17" is gesplitst naar appartementsrechten "A13", "A14" en "A15"
+            En Perceel met identificatie "P17" is niet ontstaan uit splitsing of vereniging van een ander perceel
+            En Appartementsrecht met identificatie "A13" is niet verder gesplitst of verenigd
+            En Appartementsrecht met identificatie "A14" is ondergesplitst in appartementsrechten "A16" en "A17"
+            En Appertementsrechten met identificatie "A15" en "A17" zijn samengevoegd (via wijzigingssplitsing)
+            En voor de wijzigingssplitsing zijn appartementsrechten "A13", "A14", "A15", "A16" en "A17" vervallen
+            En is appartementsrecht "A13" nieuw appartementsrecht "A18" geworden
+            En is appartementsrecht "A16" nieuw appartementsrecht "A19" geworden
+            En zijn appartementsrechten "A15" en "A17" nieuw appartementsrecht "A20" geworden
+            En Appartementsrecht met identificatie "A13" heeft "appartementsrechtVolgnummer"= 1
+            En Appartementsrecht met identificatie "A14" heeft "appartementsrechtVolgnummer"= 2
+            En Appartementsrecht met identificatie "A15" heeft "appartementsrechtVolgnummer"= 3
+            En Appartementsrecht met identificatie "A16" heeft "appartementsrechtVolgnummer"= 4
+            En Appartementsrecht met identificatie "A17" heeft "appartementsrechtVolgnummer"= 5
+            En Appartementsrecht met identificatie "A18" heeft "appartementsrechtVolgnummer"= 6
+            En Appartementsrecht met identificatie "A19" heeft "appartementsrechtVolgnummer"= 6
+            En Appartementsrecht met identificatie "A20" heeft "appartementsrechtVolgnummer"= 6
+            En Appartementsrecht met identificatie "A18" is niet verder gesplitst of verenigd
             Als "/kadastraalonroerendezaken/A14" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """

--- a/features/filiatie.feature
+++ b/features/filiatie.feature
@@ -6,12 +6,12 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
 
     Filiatie is de relatie naar de kadastraal onroerende zaken waaruit betreffende onroerende zaak is ontstaan en/of waarin de kadastraal onroerende zaak is overgegaan.
     
-    Er zijn twee soorten kadastraal onroerende zaken, een perceel en een appartementsrecht. Een perceel is een begrensd deel van het Nederlands grondgebied. Een appartementsrecht omvat de bevoegdheid tot het gebruik van bepaalde gedeelten van een gebouw die blijkens hun inrichting bestemd zijn of worden om als afzonderlijk geheel te worden gebruikt. 
+    Er zijn twee soorten kadastraal onroerende zaken, perceel en appartementsrecht. Een perceel is een begrensd deel van het Nederlands grondgebied. Een appartementsrecht omvat de bevoegdheid tot het gebruik van bepaalde gedeelten van een gebouw die blijkens hun inrichting bestemd zijn of worden om als afzonderlijk geheel te worden gebruikt. 
     
     De filiatie van een perceel wordt op een andere manier geregistreerd en daardoor ook op een andere manier in de API getoond dan een appartementsrecht.
 
     Een perceel kan worden gesplitst in meerdere nieuwe percelen. Een perceel kan ook worden samengevoegd met één of meerdere andere percelen. 
-    Wanneer een perceel wordt gesplitst of samengevoegd vervallen de oude kadastraal onroerende zaken en ontstaan er nieuwe kadastraal onroerende zaken. De vervallen kadastraal onroerende zaken (percelen) zijn dan nog wel raadpleegbaar.
+    Wanneer een perceel wordt gesplitst of samengevoegd vervallen de oude kadastraal onroerende zaken (percelen) en ontstaan er nieuwe kadastraal onroerende zaken (percelen). De vervallen kadastraal onroerende zaken (percelen) zijn dan nog wel raadpleegbaar.
 
     Een perceel kan worden gesplitst in meerdere appartementsrechten. Zowel het perceel als de daaruit gesplitste appartementsrechten zijn kadastraal onroerende zaken. Bij splitsing van een perceel in appartementsrechten blijft de kadastraal onroerende zaak van het "grondperceel" actueel, het is dan niet vervallen.
 
@@ -47,18 +47,13 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                             "code": "20",
                             "waarde": "Splitsen perceel"
                         },
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "P2"
-                        }
-                    },
-                    {
-                        "aard": {
-                            "code": "20",
-                            "waarde": "Splitsen perceel"
-                        },
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "P3"
-                        }
+                        "kadastraalOnroerendeZaken": [{
+                            "identificatie": "P2",
+                            "type": "perceel"
+                        }, {
+                            "identificatie": "P3",
+                            "type": "perceel"
+                        }]
                     }
                 ]
                 """
@@ -78,9 +73,10 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                             "code": "20",
                             "waarde": "Splitsen perceel"
                         },
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "P1"
-                        }
+                        "kadastraalOnroerendeZaken": [{
+                            "identificatie": "P1",
+                            "type": "perceel"
+                        }]
                     }
                 ]
                 """
@@ -106,9 +102,10 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                             "code": "19",
                             "waarde": "Verenigen percelen"
                         },
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "P6"
-                        }
+                        "kadastraalOnroerendeZaken": [{
+                            "identificatie": "P6",
+                            "type": "perceel"
+                        }]
                     }
                 ]
                 """
@@ -132,18 +129,15 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                             "code": "19",
                             "waarde": "Verenigen percelen"
                         },
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "P4"
-                        }
-                    },
-                    {
-                        "aard": {
-                            "code": "19",
-                            "waarde": "Verenigen percelen"
-                        },
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "P5"
-                        }
+                        "kadastraalOnroerendeZaken": [
+                            {
+                                "identificatie": "P4",
+                                "type": "perceel"
+                            }, {
+                                "identificatie": "P5",
+                                "type": "perceel"
+                            }
+                        ]
                     }
                 ]
                 """
@@ -167,14 +161,15 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                 """
                 [
                     {
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "A1"
-                        }
-                    },
-                    {
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "A2"
-                        }
+                        "kadastraalOnroerendeZaken": [
+                            {
+                                "identificatie": "A1",
+                                "type": "appartementsrecht"
+                            }, 
+                                "identificatie": "A2",
+                                "type": "appartementsrecht"
+                            }
+                        ]
                     }
                 ]
                 """
@@ -209,9 +204,10 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                 """
                 [
                     {
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "P7"
-                        }
+                        "kadastraalOnroerendeZaken": [{
+                            "identificatie": "P7",
+                            "type": "perceel"
+                        }]
                     }
                 ]
                 """
@@ -236,14 +232,15 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                 """
                 [
                     {
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "P8"
-                        }
-                    },
-                    {
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "P9"
-                        }
+                        "kadastraalOnroerendeZaken": [
+                            {
+                                "identificatie": "P8",
+                                "type": "perceel"
+                            }, {
+                                "identificatie": "P9",
+                                "type": "perceel"
+                            }
+                        ]
                     }
                 ]
                 """
@@ -270,14 +267,15 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                 """
                 [
                     {
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "A5"
-                        }
-                    },
-                    {
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "A6"
-                        }
+                        "kadastraalOnroerendeZaken": [
+                            {
+                                "identificatie": "A5",
+                                "type": "appartementsrecht"
+                            }, {
+                                "identificatie": "A6",
+                                "type": "appartementsrecht"
+                            }
+                        ]
                     }
                 ]
                 """
@@ -323,9 +321,10 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                 """
                 [
                     {
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "P10"
-                        }
+                        "kadastraalOnroerendeZaken": [{
+                            "identificatie": "P10",
+                            "type": "perceel"
+                        }]
                     }
                 ]
                 """
@@ -333,14 +332,15 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                 """
                 [
                     {
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "A7"
-                        }
-                    },
-                    {
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "A8"
-                        }
+                        "kadastraalOnroerendeZaken": [
+                            {
+                                "identificatie": "A7",
+                                "type": "appartementsrecht"
+                            }, {
+                                "identificatie": "A8",
+                                "type": "appartementsrecht"
+                            }
+                        ]
                     }
                 ]
                 """
@@ -365,9 +365,10 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                 """
                 [
                     {
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "A6"
-                        }
+                        "kadastraalOnroerendeZaken": [{
+                            "identificatie": "A6",
+                            "type": "appartementsrecht"
+                        }]
                     }
                 ]
                 """
@@ -392,9 +393,10 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                 """
                 [
                     {
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "P12"
-                        }
+                        "kadastraalOnroerendeZaken": [{
+                            "identificatie": "P12",
+                            "type": "perceel"
+                        }]
                     }
                 ]
                 """
@@ -420,9 +422,10 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                 """
                 [
                     {
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "P16"
-                        }
+                        "kadastraalOnroerendeZaken": [{
+                            "identificatie": "P16",
+                            "type": "perceel"
+                        }]
                     }
                 ]
                 """
@@ -453,27 +456,26 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             En Appartementsrecht met identificatie "A16" heeft "volgnummer"= 4
             En Appartementsrecht met identificatie "A17" heeft "volgnummer"= 5
             En Appartementsrecht met identificatie "A18" heeft "volgnummer"= 6
-            En Appartementsrecht met identificatie "A19" heeft "volgnummer"= 6
-            En Appartementsrecht met identificatie "A20" heeft "volgnummer"= 6
+            En Appartementsrecht met identificatie "A19" heeft "volgnummer"= 7
+            En Appartementsrecht met identificatie "A20" heeft "volgnummer"= 8
             En Appartementsrecht met identificatie "A18" is niet verder gesplitst of verenigd
             Als "/kadastraalonroerendezaken/P17" wordt gevraagd
             Dan bevat het antwoord "isOvergegaanIn" met waarde:    
                 """
                 [
                     {
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "A13"
-                        }
-                    },
-                    {
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "A14"
-                        }
-                    },
-                    {
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "A16"
-                        }
+                        "kadastraalOnroerendeZaken": [
+                            {
+                                "identificatie": "A13",
+                                "type": "appartementsrecht"
+                            }, {
+                                "identificatie": "A14",
+                                "type": "appartementsrecht"
+                            }, {
+                                "identificatie": "A16",
+                                "type": "appartementsrecht"
+                            }
+                        ]
                     }
                 ]
                 """
@@ -533,7 +535,7 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             En Appartementsrecht met identificatie "A13" is niet verder gesplitst of verenigd
             En Appartementsrecht met identificatie "A14" is ondergesplitst in appartementsrechten "A16" en "A17"
             En Appertementsrechten met identificatie "A15" en "A17" zijn samengevoegd (via wijzigingssplitsing)
-            En voor de wijzigingssplitsing zijn appartementsrechten "A13", "A14", "A15", "A16" en "A17" vervallen
+            En door de wijzigingssplitsing zijn appartementsrechten "A13", "A14", "A15", "A16" en "A17" vervallen
             En is appartementsrecht "A13" nieuw appartementsrecht "A18" geworden
             En is appartementsrecht "A16" nieuw appartementsrecht "A19" geworden
             En zijn appartementsrechten "A15" en "A17" nieuw appartementsrecht "A20" geworden
@@ -551,14 +553,15 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                 """
                 [
                     {
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "A14"
-                        }
-                    },
-                    {
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "P17"
-                        }
+                        "kadastraalOnroerendeZaken": [
+                            {
+                                "identificatie": "A14",
+                                "type": "appartementsrecht"
+                            }, {
+                                "identificatie": "P17",
+                                "type": "perceel"
+                            }
+                        ]
                     }
                 ]
                 """
@@ -594,9 +597,10 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                 """
                 [
                     {
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "P17"
-                        }
+                        "kadastraalOnroerendeZaken": [{
+                            "identificatie": "P17",
+                            "type": "perceel"
+                        }]
                     }
                 ]
                 """
@@ -604,9 +608,10 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                 """
                 [
                     {
-                        "kadastraalOnroerendeZaak": {
-                            "identificatie": "A16"
-                        }
+                        "kadastraalOnroerendeZaken": [{
+                            "identificatie": "A16",
+                            "type": "appartementsrecht"
+                        }]
                     }
                 ]
                 """
@@ -616,3 +621,4 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             En bevat het antwoord geen property "einddatum"
             En is de kadastraal onroerende zaak sluimerend
             En bevat het antwoord geen property "bijbehorendeAppartementsrechten"
+            

--- a/features/filiatie.feature
+++ b/features/filiatie.feature
@@ -47,22 +47,26 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                             "code": "20",
                             "waarde": "Splitsen perceel"
                         },
-                        "identificatie": "P2"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "P2"
+                        }
                     },
                     {
                         "aard": {
                             "code": "20",
                             "waarde": "Splitsen perceel"
                         },
-                        "identificatie": "P3"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "P3"
+                        }
                     }
                 ]
                 """
             En bevat het antwoord "indicatieVervallen": true
             En bevat het antwoord property "einddatum" met een waarde
-            En bevat het antwoord geen property "indicatieSluimerend"
+            En is de kadastraal onroerende zaak niet sluimerend
             En bevat het antwoord geen property "bijbehorendeGrondperceelIdentificaties"
-            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechten"
 
         Scenario: Opvragen perceel uit splitsing
             Als "/kadastraalonroerendezaken/P2" wordt gevraagd
@@ -74,16 +78,18 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                             "code": "20",
                             "waarde": "Splitsen perceel"
                         },
-                        "identificatie": "P1"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "P1"
+                        }
                     }
                 ]
                 """
             En bevat het antwoord geen property "indicatieVervallen"
             En bevat het antwoord geen property "einddatum"
-            En bevat het antwoord geen property "indicatieSluimerend"
+            En is de kadastraal onroerende zaak niet sluimerend
             En bevat het antwoord geen property "isOvergegaanIn"
             En bevat het antwoord geen property "bijbehorendeGrondperceelIdentificaties"
-            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechten"
     
     Rule: Na vereniging van percelen wordt filiatie getoond bij de vervallen percelen en bij het nieuwe perceel
         Scenario: Opvragen vervallen perceel na vereniging
@@ -100,15 +106,17 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                             "code": "19",
                             "waarde": "Verenigen percelen"
                         },
-                        "identificatie": "P6"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "P6"
+                        }
                     }
                 ]
                 """
             En bevat het antwoord "indicatieVervallen": true
             En bevat het antwoord property "einddatum" met een waarde
-            En bevat het antwoord geen property "indicatieSluimerend"
+            En is de kadastraal onroerende zaak niet sluimerend
             En bevat het antwoord geen property "bijbehorendeGrondperceelIdentificaties"
-            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechten"
 
         Scenario: Opvragen perceel uit vereniging
             Gegeven Percelen met identificatie "P4" en "P5" zijn verenigd naar perceel "P6"
@@ -124,163 +132,180 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                             "code": "19",
                             "waarde": "Verenigen percelen"
                         },
-                        "identificatie": "P4"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "P4"
+                        }
                     },
                     {
                         "aard": {
                             "code": "19",
                             "waarde": "Verenigen percelen"
                         },
-                        "identificatie": "P5"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "P5"
+                        }
                     }
                 ]
                 """
             En bevat het antwoord geen property "indicatieVervallen"
             En bevat het antwoord geen property "einddatum"
-            En bevat het antwoord geen property "indicatieSluimerend"
+            En is de kadastraal onroerende zaak niet sluimerend
             En bevat het antwoord geen property "isOvergegaanIn"
             En bevat het antwoord geen property "bijbehorendeGrondperceelIdentificaties"
-            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechten"
 
     Rule: Splitsing in appartementsrechten van een perceel toont verwijzingen van het grondperceel naar de appartementsrechten en vice versa
         Scenario: Opvragen van het grondperceel na splitsing in appartementsrechten
             Gegeven Perceel met identificatie "P7" is gesplitst naar appartementsrechten "A1" en "A2"
             En Perceel met identificatie "P7" is niet ontstaan uit splitsing of vereniging van een ander perceel
             En Appartementsrecht met identificatie "A1" is niet verder gesplitst of verenigd
-            En Appartementsrecht met identificatie "A1" heeft "appartementsrechtVolgnummer"= 1
+            En Appartementsrecht met identificatie "A1" heeft "volgnummer"= 1
             En Appartementsrecht met identificatie "A2" is niet verder gesplitst of verenigd
-            En Appartementsrecht met identificatie "A2" heeft "appartementsrechtVolgnummer"= 2
+            En Appartementsrecht met identificatie "A2" heeft "volgnummer"= 2
             Als "/kadastraalonroerendezaken/P7" wordt gevraagd
             Dan bevat het antwoord "isOvergegaanIn" met waarde:    
                 """
                 [
                     {
-                        "identificatie": "A1"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "A1"
+                        }
                     },
                     {
-                        "identificatie": "A2"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "A2"
+                        }
                     }
                 ]
                 """
-            En bevat het antwoord "bijbehorendeAppartementsrechtIdentificaties" met waarde:    
+            En bevat het antwoord "bijbehorendeAppartementsrechten" met waarde:    
                 """
                 [
                     {
                         "identificatie": "A1",
-                        "appartementsrechtVolgnummer": 1
+                        "volgnummer": 1
                     },
                     {
                         "identificatie": "A2",
-                        "appartementsrechtVolgnummer": 1
+                        "volgnummer": 2
                     }
                 ]
                 """
             En bevat het antwoord geen property "indicatieVervallen"
             En bevat het antwoord geen property "einddatum"
-            En bevat het antwoord geen property "indicatieSluimerend"
-            En bevat het antwoord geen property "appartementsrechtVolgnummer"
+            En is de kadastraal onroerende zaak niet sluimerend
+            En bevat het antwoord geen property "volgnummer"
             En bevat het antwoord geen property "bijbehorendeGrondperceelIdentificaties"
 
         Scenario: Opvragen appartementsrecht uit splitsing
             Gegeven Perceel met identificatie "P7" is gesplitst naar appartementsrechten "A1" en "A2"
             En Perceel met identificatie "P7" is niet ontstaan uit splitsing of vereniging van een ander perceel
             En Appartementsrecht met identificatie "A1" is niet verder gesplitst of verenigd
-            En Appartementsrecht met identificatie "A1" heeft "appartementsrechtVolgnummer"= 1
+            En Appartementsrecht met identificatie "A1" heeft "volgnummer"= 1
             En Appartementsrecht met identificatie "A2" is niet verder gesplitst of verenigd
-            En Appartementsrecht met identificatie "A2" heeft "appartementsrechtVolgnummer"= 2
+            En Appartementsrecht met identificatie "A2" heeft "volgnummer"= 2
             Als "/kadastraalonroerendezaken/A1" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
                 [
                     {
-                        "identificatie": "P7"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "P7"
+                        }
                     }
                 ]
                 """
             En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P7" ]
-            En bevat het antwoord "appartementsrechtVolgnummer": 1
+            En bevat het antwoord "volgnummer": 1
             En bevat het antwoord geen property "indicatieVervallen"
             En bevat het antwoord geen property "einddatum"
-            En bevat het antwoord geen property "indicatieSluimerend"
+            En is de kadastraal onroerende zaak niet sluimerend
             En bevat het antwoord geen property "isOvergegaanIn"
-            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechten"
 
         Scenario: Opvragen appartementsrecht met meerdere bijbehorende grondpercelen
             Gegeven Percelen met identificatie "P8" en "P9" zijn gesplitst naar appartementsrechten "A3" en "A4"
             En Perceel met identificatie "P8" is niet ontstaan uit splitsing of vereniging van een ander perceel
             En Perceel met identificatie "P9" is niet ontstaan uit splitsing of vereniging van een ander perceel
             En Appartementsrecht met identificatie "A3" is niet verder gesplitst of verenigd
-            En Appartementsrecht met identificatie "A3" heeft "appartementsrechtVolgnummer"= 1
+            En Appartementsrecht met identificatie "A3" heeft "volgnummer"= 1
             En Appartementsrecht met identificatie "A4" is niet verder gesplitst of verenigd
-            En Appartementsrecht met identificatie "A4" heeft "appartementsrechtVolgnummer"= 2
+            En Appartementsrecht met identificatie "A4" heeft "volgnummer"= 2
             Als "/kadastraalonroerendezaken/A3" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
                 [
                     {
-                        "identificatie": "P8"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "P8"
+                        }
                     },
                     {
-                        "identificatie": "P9"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "P9"
+                        }
                     }
                 ]
                 """
             En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P8", "P9" ]
-            En bevat het antwoord "appartementsrechtVolgnummer": 1
+            En bevat het antwoord "volgnummer": 1
             En bevat het antwoord geen property "indicatieVervallen"
             En bevat het antwoord geen property "einddatum"
-            En bevat het antwoord geen property "indicatieSluimerend"
+            En is de kadastraal onroerende zaak niet sluimerend
             En bevat het antwoord geen property "isOvergegaanIn"
-            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechten"
 
-    Rule: Bij ondersplitsing van een appartementsrecht worden alle bijbehorende appartementsrechten getoond bij het perceel en wordt indicatieSluimerend getoond bij het sluimerende appartementsrecht
+    Rule: Bij ondersplitsing van een appartementsrecht worden alle bijbehorende appartementsrechten getoond bij het perceel
         Scenario: Opvragen van het grondperceel na splitsing in appartementsrechten en ondersplitsing van een appartementsrecht
             Gegeven Perceel met identificatie "P10" is gesplitst naar appartementsrechten "A5" en "A6"
             En Perceel met identificatie "P10" is niet ontstaan uit splitsing of vereniging van een ander perceel
             En Appartementsrecht met identificatie "A5" is niet verder gesplitst of verenigd
-            En Appartementsrecht met identificatie "A5" heeft "appartementsrechtVolgnummer"= 1
+            En Appartementsrecht met identificatie "A5" heeft "volgnummer"= 1
             En Appartementsrecht met identificatie "A6" is ondergesplitst in appartementsrechten "A7" en "A8"
-            En Appartementsrecht met identificatie "A6" heeft "appartementsrechtVolgnummer"= 2
-            En Appartementsrecht met identificatie "A7" heeft "appartementsrechtVolgnummer"= 3
-            En Appartementsrecht met identificatie "A8" heeft "appartementsrechtVolgnummer"= 4
+            En Appartementsrecht met identificatie "A6" heeft "volgnummer"= 2
+            En Appartementsrecht met identificatie "A7" heeft "volgnummer"= 3
+            En Appartementsrecht met identificatie "A8" heeft "volgnummer"= 4
             Als "/kadastraalonroerendezaken/P10" wordt gevraagd
             Dan bevat het antwoord "isOvergegaanIn" met waarde:
                 """
                 [
                     {
-                        "identificatie": "A5"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "A5"
+                        }
                     },
                     {
-                        "identificatie": "A6"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "A6"
+                        }
                     }
                 ]
                 """
-            En bevat het antwoord "bijbehorendeAppartementsrechtIdentificaties" met waarde:    
+            En bevat het antwoord "bijbehorendeAppartementsrechten" met waarde:    
                 """
                 [
                     {
                         "identificatie": "A5",
-                        "appartementsrechtVolgnummer": 1
+                        "volgnummer": 1
                     },
                     {
                         "identificatie": "A6",
-                        "appartementsrechtVolgnummer": 2,
-                        "indicatieSluimerend": true
+                        "volgnummer": 2
                     },
                     {
                         "identificatie": "A7",
-                        "appartementsrechtVolgnummer": 3
+                        "volgnummer": 3
                     },
                     {
                         "identificatie": "A8",
-                        "appartementsrechtVolgnummer": 4
+                        "volgnummer": 4
                     }
                 ]
                 """
             En bevat het antwoord geen property "indicatieVervallen"
             En bevat het antwoord geen property "einddatum"
-            En bevat het antwoord geen property "indicatieSluimerend"
-            En bevat het antwoord geen property "appartementsrechtVolgnummer"
+            En is de kadastraal onroerende zaak niet sluimerend
+            En bevat het antwoord geen property "volgnummer"
             En bevat het antwoord geen property "bijbehorendeGrondperceelIdentificaties"
 
     Rule: Na ondersplitsing van een appartementsrecht toont de filiatie één stap omhoog of omlaag, plus het bijbehorende grondperceel
@@ -288,17 +313,19 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             Gegeven Perceel met identificatie "P10" is gesplitst naar appartementsrechten "A5" en "A6"
             En Perceel met identificatie "P10" is niet ontstaan uit splitsing of vereniging van een ander perceel
             En Appartementsrecht met identificatie "A5" is niet verder gesplitst of verenigd
-            En Appartementsrecht met identificatie "A5" heeft "appartementsrechtVolgnummer"= 1
+            En Appartementsrecht met identificatie "A5" heeft "volgnummer"= 1
             En Appartementsrecht met identificatie "A6" is ondergesplitst in appartementsrechten "A7" en "A8"
-            En Appartementsrecht met identificatie "A6" heeft "appartementsrechtVolgnummer"= 2
-            En Appartementsrecht met identificatie "A7" heeft "appartementsrechtVolgnummer"= 3
-            En Appartementsrecht met identificatie "A8" heeft "appartementsrechtVolgnummer"= 4
+            En Appartementsrecht met identificatie "A6" heeft "volgnummer"= 2
+            En Appartementsrecht met identificatie "A7" heeft "volgnummer"= 3
+            En Appartementsrecht met identificatie "A8" heeft "volgnummer"= 4
             Als "/kadastraalonroerendezaken/A6" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
                 [
                     {
-                        "identificatie": "P10"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "P10"
+                        }
                     }
                 ]
                 """
@@ -306,98 +333,108 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                 """
                 [
                     {
-                        "identificatie": "A7"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "A7"
+                        }
                     },
                     {
-                        "identificatie": "A8"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "A8"
+                        }
                     }
                 ]
                 """
             En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P10" ]
-            En bevat het antwoord "appartementsrechtVolgnummer": 2
+            En bevat het antwoord "volgnummer": 2
             En bevat het antwoord geen property "indicatieVervallen"
             En bevat het antwoord geen property "einddatum"
-            En bevat het antwoord "indicatieSluimerend": true
-            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+            En is de kadastraal onroerende zaak sluimerend
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechten"
 
         Scenario: Opvragen appartementsrecht uit ondersplitsing
             Gegeven Perceel met identificatie "P10" is gesplitst naar appartementsrechten "A5" en "A6"
             En Perceel met identificatie "P10" is niet ontstaan uit splitsing of vereniging van een ander perceel
             En Appartementsrecht met identificatie "A5" is niet verder gesplitst of verenigd
-            En Appartementsrecht met identificatie "A5" heeft "appartementsrechtVolgnummer"= 1
+            En Appartementsrecht met identificatie "A5" heeft "volgnummer"= 1
             En Appartementsrecht met identificatie "A6" is ondergesplitst in appartementsrechten "A7" en "A8"
-            En Appartementsrecht met identificatie "A6" heeft "appartementsrechtVolgnummer"= 2
-            En Appartementsrecht met identificatie "A7" heeft "appartementsrechtVolgnummer"= 3
-            En Appartementsrecht met identificatie "A8" heeft "appartementsrechtVolgnummer"= 4
+            En Appartementsrecht met identificatie "A6" heeft "volgnummer"= 2
+            En Appartementsrecht met identificatie "A7" heeft "volgnummer"= 3
+            En Appartementsrecht met identificatie "A8" heeft "volgnummer"= 4
             Als "/kadastraalonroerendezaken/A7" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
                 [
                     {
-                        "identificatie": "A6"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "A6"
+                        }
                     }
                 ]
                 """
             En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P10" ]
-            En bevat het antwoord "appartementsrechtVolgnummer": 3
+            En bevat het antwoord "volgnummer": 3
             En bevat het antwoord geen property "indicatieVervallen"
             En bevat het antwoord geen property "einddatum"
-            En bevat het antwoord geen property "indicatieSluimerend"
+            En is de kadastraal onroerende zaak niet sluimerend
             En bevat het antwoord geen property "isOvergegaanIn"
-            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechten"
 
     Rule: Een vervallen (verenigd of gesplitst) perceel wordt niet getoond als bijbehorend grondperceel 
         Scenario: Opvragen appartementsrecht met grondperceel uit splitsing
             Gegeven Perceel met identificatie "P11" is gesplitst naar percelen "P12" en "P13"
             En Perceel met identificatie "P12" is gesplitst naar appartementsrechten "A9" en "A10"
             En Appartementsrecht met identificatie "A9" is niet verder gesplitst of verenigd
-            En Appartementsrecht met identificatie "A9" heeft "appartementsrechtVolgnummer"= 1
+            En Appartementsrecht met identificatie "A9" heeft "volgnummer"= 1
             En Appartementsrecht met identificatie "A10" is niet verder gesplitst of verenigd
-            En Appartementsrecht met identificatie "A10" heeft "appartementsrechtVolgnummer"= 2
+            En Appartementsrecht met identificatie "A10" heeft "volgnummer"= 2
             Als "/kadastraalonroerendezaken/A9" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
                 [
                     {
-                        "identificatie": "P12"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "P12"
+                        }
                     }
                 ]
                 """
             En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P12" ]
             En bevat het antwoord in "bijbehorendeGrondperceelIdentificaties" geen waarde "P11"
             En bevat het antwoord in "bijbehorendeGrondperceelIdentificaties" geen waarde "P13"
-            En bevat het antwoord "appartementsrechtVolgnummer": 1
+            En bevat het antwoord "volgnummer": 1
             En bevat het antwoord geen property "indicatieVervallen"
             En bevat het antwoord geen property "einddatum"
-            En bevat het antwoord geen property "indicatieSluimerend"
+            En is de kadastraal onroerende zaak niet sluimerend
             En bevat het antwoord geen property "isOvergegaanIn"
-            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechten"
 
         Scenario: Opvragen appartementsrecht met grondperceel uit vereniging
             Gegeven Percelen met identificatie "P14" en "P15" zijn verenigd naar perceel "P16"
             En Perceel met identificatie "P16" is gesplitst naar appartementsrechten "A11" en "A12"
             En Appartementsrecht met identificatie "A11" is niet verder gesplitst of verenigd
-            En Appartementsrecht met identificatie "A11" heeft "appartementsrechtVolgnummer"= 1
+            En Appartementsrecht met identificatie "A11" heeft "volgnummer"= 1
             En Appartementsrecht met identificatie "A12" is niet verder gesplitst of verenigd
-            En Appartementsrecht met identificatie "A12" heeft "appartementsrechtVolgnummer"= 2
+            En Appartementsrecht met identificatie "A12" heeft "volgnummer"= 2
             Als "/kadastraalonroerendezaken/A11" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
                 [
                     {
-                        "identificatie": "P16"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "P16"
+                        }
                     }
                 ]
                 """
             En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P16" ]
             En bevat het antwoord in "bijbehorendeGrondperceelIdentificaties" geen waarde "P14"
             En bevat het antwoord in "bijbehorendeGrondperceelIdentificaties" geen waarde "P15"
-            En bevat het antwoord "appartementsrechtVolgnummer": 1
+            En bevat het antwoord "volgnummer": 1
             En bevat het antwoord geen property "indicatieVervallen"
             En bevat het antwoord geen property "einddatum"
-            En bevat het antwoord geen property "indicatieSluimerend"
+            En is de kadastraal onroerende zaak niet sluimerend
             En bevat het antwoord geen property "isOvergegaanIn"
-            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechten"
     
     Rule: Na een wijzigingssplitsing van een appartementsrecht worden de vervallen appartementsrechten niet getoond en wordt de filiatie uit het oude appartementsrecht overgenomen in de nieuwe appartementsrechten
         Scenario: Opvragen van het grondperceel na wijzigingssplitsing van appartementsrechten
@@ -410,56 +447,61 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             En is appartementsrecht "A13" nieuw appartementsrecht "A18" geworden
             En is appartementsrecht "A16" nieuw appartementsrecht "A19" geworden
             En zijn appartementsrechten "A15" en "A17" nieuw appartementsrecht "A20" geworden
-            En Appartementsrecht met identificatie "A13" heeft "appartementsrechtVolgnummer"= 1
-            En Appartementsrecht met identificatie "A14" heeft "appartementsrechtVolgnummer"= 2
-            En Appartementsrecht met identificatie "A15" heeft "appartementsrechtVolgnummer"= 3
-            En Appartementsrecht met identificatie "A16" heeft "appartementsrechtVolgnummer"= 4
-            En Appartementsrecht met identificatie "A17" heeft "appartementsrechtVolgnummer"= 5
-            En Appartementsrecht met identificatie "A18" heeft "appartementsrechtVolgnummer"= 6
-            En Appartementsrecht met identificatie "A19" heeft "appartementsrechtVolgnummer"= 6
-            En Appartementsrecht met identificatie "A20" heeft "appartementsrechtVolgnummer"= 6
+            En Appartementsrecht met identificatie "A13" heeft "volgnummer"= 1
+            En Appartementsrecht met identificatie "A14" heeft "volgnummer"= 2
+            En Appartementsrecht met identificatie "A15" heeft "volgnummer"= 3
+            En Appartementsrecht met identificatie "A16" heeft "volgnummer"= 4
+            En Appartementsrecht met identificatie "A17" heeft "volgnummer"= 5
+            En Appartementsrecht met identificatie "A18" heeft "volgnummer"= 6
+            En Appartementsrecht met identificatie "A19" heeft "volgnummer"= 6
+            En Appartementsrecht met identificatie "A20" heeft "volgnummer"= 6
             En Appartementsrecht met identificatie "A18" is niet verder gesplitst of verenigd
             Als "/kadastraalonroerendezaken/P17" wordt gevraagd
             Dan bevat het antwoord "isOvergegaanIn" met waarde:    
                 """
                 [
                     {
-                        "identificatie": "A13"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "A13"
+                        }
                     },
                     {
-                        "identificatie": "A14"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "A14"
+                        }
                     },
                     {
-                        "identificatie": "A16"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "A16"
+                        }
                     }
                 ]
                 """
-            En bevat het antwoord "bijbehorendeAppartementsrechtIdentificaties" met waarde:    
+            En bevat het antwoord "bijbehorendeAppartementsrechten" met waarde:    
                 """
                 [
                     {
                         "identificatie": "A13",
-                        "appartementsrechtVolgnummer": 1
+                        "volgnummer": 1
                     },
                     {
                         "identificatie": "A14",
-                        "appartementsrechtVolgnummer": 2,
-                        "indicatieSluimerend": true
+                        "volgnummer": 2
                     },
                     {
                         "identificatie": "A16",
-                        "appartementsrechtVolgnummer": 4
+                        "volgnummer": 4
                     },
                     {
                         "identificatie": "A18",
-                        "appartementsrechtVolgnummer": 6
+                        "volgnummer": 6
                     }
                 ]
                 """
             En bevat het antwoord geen property "indicatieVervallen"
             En bevat het antwoord geen property "einddatum"
-            En bevat het antwoord geen property "indicatieSluimerend"
-            En bevat het antwoord geen property "appartementsrechtVolgnummer"
+            En is de kadastraal onroerende zaak niet sluimerend
+            En bevat het antwoord geen property "volgnummer"
             En bevat het antwoord geen property "bijbehorendeGrondperceelIdentificaties"
 
         Scenario: Opvragen van een vervallen appartementsrecht
@@ -472,14 +514,14 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             En is appartementsrecht "A13" nieuw appartementsrecht "A18" geworden
             En is appartementsrecht "A16" nieuw appartementsrecht "A19" geworden
             En zijn appartementsrechten "A15" en "A17" nieuw appartementsrecht "A20" geworden
-            En Appartementsrecht met identificatie "A13" heeft "appartementsrechtVolgnummer"= 1
-            En Appartementsrecht met identificatie "A14" heeft "appartementsrechtVolgnummer"= 2
-            En Appartementsrecht met identificatie "A15" heeft "appartementsrechtVolgnummer"= 3
-            En Appartementsrecht met identificatie "A16" heeft "appartementsrechtVolgnummer"= 4
-            En Appartementsrecht met identificatie "A17" heeft "appartementsrechtVolgnummer"= 5
-            En Appartementsrecht met identificatie "A18" heeft "appartementsrechtVolgnummer"= 6
-            En Appartementsrecht met identificatie "A19" heeft "appartementsrechtVolgnummer"= 6
-            En Appartementsrecht met identificatie "A20" heeft "appartementsrechtVolgnummer"= 6
+            En Appartementsrecht met identificatie "A13" heeft "volgnummer"= 1
+            En Appartementsrecht met identificatie "A14" heeft "volgnummer"= 2
+            En Appartementsrecht met identificatie "A15" heeft "volgnummer"= 3
+            En Appartementsrecht met identificatie "A16" heeft "volgnummer"= 4
+            En Appartementsrecht met identificatie "A17" heeft "volgnummer"= 5
+            En Appartementsrecht met identificatie "A18" heeft "volgnummer"= 6
+            En Appartementsrecht met identificatie "A19" heeft "volgnummer"= 6
+            En Appartementsrecht met identificatie "A20" heeft "volgnummer"= 6
             En Appartementsrecht met identificatie "A18" is niet verder gesplitst of verenigd
             Als "/kadastraalonroerendezaken/A15" wordt gevraagd
             Dan geeft het antwoord http statuscode 410
@@ -495,34 +537,38 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             En is appartementsrecht "A13" nieuw appartementsrecht "A18" geworden
             En is appartementsrecht "A16" nieuw appartementsrecht "A19" geworden
             En zijn appartementsrechten "A15" en "A17" nieuw appartementsrecht "A20" geworden
-            En Appartementsrecht met identificatie "A13" heeft "appartementsrechtVolgnummer"= 1
-            En Appartementsrecht met identificatie "A14" heeft "appartementsrechtVolgnummer"= 2
-            En Appartementsrecht met identificatie "A15" heeft "appartementsrechtVolgnummer"= 3
-            En Appartementsrecht met identificatie "A16" heeft "appartementsrechtVolgnummer"= 4
-            En Appartementsrecht met identificatie "A17" heeft "appartementsrechtVolgnummer"= 5
-            En Appartementsrecht met identificatie "A18" heeft "appartementsrechtVolgnummer"= 6
-            En Appartementsrecht met identificatie "A19" heeft "appartementsrechtVolgnummer"= 6
-            En Appartementsrecht met identificatie "A20" heeft "appartementsrechtVolgnummer"= 6
+            En Appartementsrecht met identificatie "A13" heeft "volgnummer"= 1
+            En Appartementsrecht met identificatie "A14" heeft "volgnummer"= 2
+            En Appartementsrecht met identificatie "A15" heeft "volgnummer"= 3
+            En Appartementsrecht met identificatie "A16" heeft "volgnummer"= 4
+            En Appartementsrecht met identificatie "A17" heeft "volgnummer"= 5
+            En Appartementsrecht met identificatie "A18" heeft "volgnummer"= 6
+            En Appartementsrecht met identificatie "A19" heeft "volgnummer"= 6
+            En Appartementsrecht met identificatie "A20" heeft "volgnummer"= 6
             En Appartementsrecht met identificatie "A18" is niet verder gesplitst of verenigd
             Als "/kadastraalonroerendezaken/A18" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
                 [
                     {
-                        "identificatie": "A14",
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "A14"
+                        }
                     },
                     {
-                        "identificatie": "P17"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "P17"
+                        }
                     }
                 ]
                 """
             En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P17" ]
-            En bevat het antwoord "appartementsrechtVolgnummer": 6
+            En bevat het antwoord "volgnummer": 6
             En bevat het antwoord geen property "indicatieVervallen"
             En bevat het antwoord geen property "einddatum"
-            En bevat het antwoord geen property "indicatieSluimerend"
+            En is de kadastraal onroerende zaak niet sluimerend
             En bevat het antwoord geen property "isOvergegaanIn"
-            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechten"
 
         Scenario: opvragen van sluimerend appartementsrecht na wijzigingssplitsing in gesplitst perceel
             Gegeven Perceel met identificatie "P17" is gesplitst naar appartementsrechten "A13", "A14" en "A15"
@@ -534,21 +580,23 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             En is appartementsrecht "A13" nieuw appartementsrecht "A18" geworden
             En is appartementsrecht "A16" nieuw appartementsrecht "A19" geworden
             En zijn appartementsrechten "A15" en "A17" nieuw appartementsrecht "A20" geworden
-            En Appartementsrecht met identificatie "A13" heeft "appartementsrechtVolgnummer"= 1
-            En Appartementsrecht met identificatie "A14" heeft "appartementsrechtVolgnummer"= 2
-            En Appartementsrecht met identificatie "A15" heeft "appartementsrechtVolgnummer"= 3
-            En Appartementsrecht met identificatie "A16" heeft "appartementsrechtVolgnummer"= 4
-            En Appartementsrecht met identificatie "A17" heeft "appartementsrechtVolgnummer"= 5
-            En Appartementsrecht met identificatie "A18" heeft "appartementsrechtVolgnummer"= 6
-            En Appartementsrecht met identificatie "A19" heeft "appartementsrechtVolgnummer"= 6
-            En Appartementsrecht met identificatie "A20" heeft "appartementsrechtVolgnummer"= 6
+            En Appartementsrecht met identificatie "A13" heeft "volgnummer"= 1
+            En Appartementsrecht met identificatie "A14" heeft "volgnummer"= 2
+            En Appartementsrecht met identificatie "A15" heeft "volgnummer"= 3
+            En Appartementsrecht met identificatie "A16" heeft "volgnummer"= 4
+            En Appartementsrecht met identificatie "A17" heeft "volgnummer"= 5
+            En Appartementsrecht met identificatie "A18" heeft "volgnummer"= 6
+            En Appartementsrecht met identificatie "A19" heeft "volgnummer"= 6
+            En Appartementsrecht met identificatie "A20" heeft "volgnummer"= 6
             En Appartementsrecht met identificatie "A18" is niet verder gesplitst of verenigd
             Als "/kadastraalonroerendezaken/A14" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
                 [
                     {
-                        "identificatie": "P17"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "P17"
+                        }
                     }
                 ]
                 """
@@ -556,13 +604,15 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
                 """
                 [
                     {
-                        "identificatie": "A16"
+                        "kadastraalOnroerendeZaak": {
+                            "identificatie": "A16"
+                        }
                     }
                 ]
                 """
             En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P17" ]
-            En bevat het antwoord "appartementsrechtVolgnummer": 2
+            En bevat het antwoord "volgnummer": 2
             En bevat het antwoord geen property "indicatieVervallen"
             En bevat het antwoord geen property "einddatum"
-            En bevat het antwoord "indicatieSluimerend": true
-            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+            En is de kadastraal onroerende zaak sluimerend
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechten"

--- a/features/filiatie.feature
+++ b/features/filiatie.feature
@@ -1,6 +1,34 @@
 # language: nl
 
 Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroerende zaken
+    Zodat ik inzicht heb in de splitsingen en samenvoegingen waarbij de kadastraal onroerende zaak betrokken is geweest.
+    En zodat ik inzicht heb in alle splitsingen en samenvoegingen die hebben plaatsgevonden tot en met de uitgifte van de grond door de gemeente.
+
+    Filiatie is de relatie naar de kadastraal onroerende zaken waaruit betreffende onroerende zaak is ontstaan en/of waarin de kadastraal onroerende zaak is overgegaan.
+    
+    Er zijn twee soorten kadastraal onroerende zaken, een perceel en een appartementsrecht. Een perceel is een begrensd deel van het Nederlands grondgebied. Een appartementsrecht omvat de bevoegdheid tot het gebruik van bepaalde gedeelten van een gebouw die blijkens hun inrichting bestemd zijn of worden om als afzonderlijk geheel te worden gebruikt. 
+    
+    De filiatie van een perceel wordt op een andere manier geregistreerd en daardoor ook op een andere manier in de API getoond dan een appartementsrecht.
+
+    Een perceel kan worden gesplitst in meerdere nieuwe percelen. Een perceel kan ook worden samengevoegd met één of meerdere andere percelen. 
+    Wanneer een perceel wordt gesplitst of samengevoegd vervallen de oude kadastraal onroerende zaken en ontstaan er nieuwe kadastraal onroerende zaken. De vervallen kadastraal onroerende zaken (percelen) zijn dan nog wel raadpleegbaar.
+
+    Een perceel kan worden gesplitst in meerdere appartementsrechten. Zowel het perceel als de daaruit gesplitste appartementsrechten zijn kadastraal onroerende zaken. Bij splitsing van een perceel in appartementsrechten blijft de kadastraal onroerende zaak van het "grondperceel" actueel, het is dan niet vervallen.
+
+    Een appartementsrecht kan worden gesplitst in meerdere nieuwe appartementsrechten. Dit heet "ondersplitsing" van het appartementsrecht. In dat geval wordt de oude kadastraal onroerende zaak (het oude appartementsrecht) "sluimerend". Dat oude appartementsrecht is dan dus niet vervallen en blijft ook raadpleegbaar.
+
+    Wanneer een appartementsrechtsplitsing moet worden gewijzigd, bijvoorbeeld wanneer appartementsrechten worden samengevoegd, dan vervallen de oude kadastraal onroerende zaken (appartementsrechten). De oude kadastraal onroerende zaken (appartementsrechten) vervallen dan en zijn niet meer raadpleegbaar. De filiatie van de oude kadastraal onroerende zaken (vervallen appartementsrechten) wordt dan overgenomen in de nieuwe kadastraal onroerende zaken (appartementsrechten).
+
+    In een overzicht:
+    | gebeurtenis                               | status oude kadastraal onroerende zaak/zaken | oude kadastraal onroerende zaak/zaken raadpleegbaar |
+    | splitsen van perceel in nieuwe percelen   | vervallen                                    | ja                                                  |
+    | samenvoegen van percelen                  | vervallen                                    | ja                                                  |
+    | splitsen perceel in appartementsrechten   | actueel                                      | ja                                                  |
+    | ondersplitsing van appartementsrecht      | sluimerend                                   | ja                                                  |
+    | wijzigingssplitsing van appartementsrecht | vervallen                                    | nee                                                 |
+
+
+    Naast de filiatie worden relaties naar de grondpercelen waaruit het appartementsrecht is ontstaan of naar de appartementsrechten horend bij het perceel geleverd, zodat direct de bijbehorende grondpercelen dan wel bijbehorende appartementsrechten kunnen worden opgehaald, zonder eerst via eventuele sluimerende appartementsrechten de filiatie af te hoeven lopen.
 
     #TODO: invullen onroerende zaak identificaties
 

--- a/features/filiatie.feature
+++ b/features/filiatie.feature
@@ -41,21 +41,19 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             Als "/kadastraalonroerendezaken/P1" wordt gevraagd
             Dan bevat het antwoord "isOvergegaanIn" met waarde:    
                 """
-                [
-                    {
-                        "aard": {
-                            "code": "20",
-                            "waarde": "Splitsen perceel"
-                        },
-                        "kadastraalOnroerendeZaken": [{
-                            "identificatie": "P2",
-                            "type": "perceel"
-                        }, {
-                            "identificatie": "P3",
-                            "type": "perceel"
-                        }]
-                    }
-                ]
+                {
+                    "aard": {
+                        "code": "20",
+                        "waarde": "Splitsen perceel"
+                    },
+                    "kadastraalOnroerendeZaken": [{
+                        "identificatie": "P2",
+                        "type": "perceel"
+                    }, {
+                        "identificatie": "P3",
+                        "type": "perceel"
+                    }]
+                }
                 """
             En bevat het antwoord "indicatieVervallen": true
             En bevat het antwoord property "einddatum" met een waarde
@@ -67,18 +65,16 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             Als "/kadastraalonroerendezaken/P2" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
-                [
-                    {
-                        "aard": {
-                            "code": "20",
-                            "waarde": "Splitsen perceel"
-                        },
-                        "kadastraalOnroerendeZaken": [{
-                            "identificatie": "P1",
-                            "type": "perceel"
-                        }]
-                    }
-                ]
+                {
+                    "aard": {
+                        "code": "20",
+                        "waarde": "Splitsen perceel"
+                    },
+                    "kadastraalOnroerendeZaken": [{
+                        "identificatie": "P1",
+                        "type": "perceel"
+                    }]
+                }
                 """
             En bevat het antwoord geen property "indicatieVervallen"
             En bevat het antwoord geen property "einddatum"
@@ -96,18 +92,16 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             Als "/kadastraalonroerendezaken/P4" wordt gevraagd
             Dan bevat het antwoord "isOvergegaanIn" met waarde:    
                 """
-                [
-                    {
-                        "aard": {
-                            "code": "19",
-                            "waarde": "Verenigen percelen"
-                        },
-                        "kadastraalOnroerendeZaken": [{
-                            "identificatie": "P6",
-                            "type": "perceel"
-                        }]
-                    }
-                ]
+                {
+                    "aard": {
+                        "code": "19",
+                        "waarde": "Verenigen percelen"
+                    },
+                    "kadastraalOnroerendeZaken": [{
+                        "identificatie": "P6",
+                        "type": "perceel"
+                    }]
+                }
                 """
             En bevat het antwoord "indicatieVervallen": true
             En bevat het antwoord property "einddatum" met een waarde
@@ -123,23 +117,21 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             Als "/kadastraalonroerendezaken/P6" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
-                [
-                    {
-                        "aard": {
-                            "code": "19",
-                            "waarde": "Verenigen percelen"
-                        },
-                        "kadastraalOnroerendeZaken": [
-                            {
-                                "identificatie": "P4",
-                                "type": "perceel"
-                            }, {
-                                "identificatie": "P5",
-                                "type": "perceel"
-                            }
-                        ]
-                    }
-                ]
+                {
+                    "aard": {
+                        "code": "19",
+                        "waarde": "Verenigen percelen"
+                    },
+                    "kadastraalOnroerendeZaken": [
+                        {
+                            "identificatie": "P4",
+                            "type": "perceel"
+                        }, {
+                            "identificatie": "P5",
+                            "type": "perceel"
+                        }
+                    ]
+                }
                 """
             En bevat het antwoord geen property "indicatieVervallen"
             En bevat het antwoord geen property "einddatum"
@@ -159,32 +151,32 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             Als "/kadastraalonroerendezaken/P7" wordt gevraagd
             Dan bevat het antwoord "isOvergegaanIn" met waarde:    
                 """
-                [
-                    {
-                        "kadastraalOnroerendeZaken": [
-                            {
-                                "identificatie": "A1",
-                                "type": "appartementsrecht"
-                            }, 
-                                "identificatie": "A2",
-                                "type": "appartementsrecht"
-                            }
-                        ]
-                    }
-                ]
+                {
+                    "aard": {
+                        "code": "25",
+                        "waarde": "Splitsing in appartementsrechten"
+                    },
+                    "kadastraalOnroerendeZaken": [
+                        {
+                            "identificatie": "A1",
+                            "type": "appartementsrecht"
+                        }, 
+                            "identificatie": "A2",
+                            "type": "appartementsrecht"
+                        }
+                    ]
+                }
                 """
             En bevat het antwoord "bijbehorendeAppartementsrechten" met waarde:    
                 """
-                [
-                    {
-                        "identificatie": "A1",
-                        "volgnummer": 1
-                    },
-                    {
-                        "identificatie": "A2",
-                        "volgnummer": 2
-                    }
-                ]
+                {
+                    "identificatie": "A1",
+                    "volgnummer": 1
+                },
+                {
+                    "identificatie": "A2",
+                    "volgnummer": 2
+                }
                 """
             En bevat het antwoord geen property "indicatieVervallen"
             En bevat het antwoord geen property "einddatum"
@@ -202,14 +194,16 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             Als "/kadastraalonroerendezaken/A1" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
-                [
-                    {
-                        "kadastraalOnroerendeZaken": [{
-                            "identificatie": "P7",
-                            "type": "perceel"
-                        }]
-                    }
-                ]
+                {
+                    "aard": {
+                        "code": "25",
+                        "waarde": "Splitsing in appartementsrechten"
+                    },
+                    "kadastraalOnroerendeZaken": [{
+                        "identificatie": "P7",
+                        "type": "perceel"
+                    }]
+                }
                 """
             En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P7" ]
             En bevat het antwoord "volgnummer": 1
@@ -230,19 +224,21 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             Als "/kadastraalonroerendezaken/A3" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
-                [
-                    {
-                        "kadastraalOnroerendeZaken": [
-                            {
-                                "identificatie": "P8",
-                                "type": "perceel"
-                            }, {
-                                "identificatie": "P9",
-                                "type": "perceel"
-                            }
-                        ]
-                    }
-                ]
+                {
+                    "aard": {
+                        "code": "25",
+                        "waarde": "Splitsing in appartementsrechten"
+                    },
+                    "kadastraalOnroerendeZaken": [
+                        {
+                            "identificatie": "P8",
+                            "type": "perceel"
+                        }, {
+                            "identificatie": "P9",
+                            "type": "perceel"
+                        }
+                    ]
+                }
                 """
             En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P8", "P9" ]
             En bevat het antwoord "volgnummer": 1
@@ -265,19 +261,21 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             Als "/kadastraalonroerendezaken/P10" wordt gevraagd
             Dan bevat het antwoord "isOvergegaanIn" met waarde:
                 """
-                [
-                    {
-                        "kadastraalOnroerendeZaken": [
-                            {
-                                "identificatie": "A5",
-                                "type": "appartementsrecht"
-                            }, {
-                                "identificatie": "A6",
-                                "type": "appartementsrecht"
-                            }
-                        ]
-                    }
-                ]
+                {
+                    "aard": {
+                        "code": "25",
+                        "waarde": "Splitsing in appartementsrechten"
+                    },
+                    "kadastraalOnroerendeZaken": [
+                        {
+                            "identificatie": "A5",
+                            "type": "appartementsrecht"
+                        }, {
+                            "identificatie": "A6",
+                            "type": "appartementsrecht"
+                        }
+                    ]
+                }
                 """
             En bevat het antwoord "bijbehorendeAppartementsrechten" met waarde:    
                 """
@@ -319,30 +317,34 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             Als "/kadastraalonroerendezaken/A6" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
-                [
-                    {
-                        "kadastraalOnroerendeZaken": [{
-                            "identificatie": "P10",
-                            "type": "perceel"
-                        }]
-                    }
-                ]
+                {
+                    "aard": {
+                        "code": "25",
+                        "waarde": "Splitsing in appartementsrechten"
+                    },
+                    "kadastraalOnroerendeZaken": [{
+                        "identificatie": "P10",
+                        "type": "perceel"
+                    }]
+                }
                 """
             En bevat het antwoord "isOvergegaanIn" met waarde:    
                 """
-                [
-                    {
-                        "kadastraalOnroerendeZaken": [
-                            {
-                                "identificatie": "A7",
-                                "type": "appartementsrecht"
-                            }, {
-                                "identificatie": "A8",
-                                "type": "appartementsrecht"
-                            }
-                        ]
-                    }
-                ]
+                {
+                    "aard": {
+                        "code": "26",
+                        "waarde": "Ondersplitsing in appartementsrechten"
+                    },
+                    "kadastraalOnroerendeZaken": [
+                        {
+                            "identificatie": "A7",
+                            "type": "appartementsrecht"
+                        }, {
+                            "identificatie": "A8",
+                            "type": "appartementsrecht"
+                        }
+                    ]
+                }
                 """
             En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P10" ]
             En bevat het antwoord "volgnummer": 2
@@ -363,14 +365,16 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             Als "/kadastraalonroerendezaken/A7" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
-                [
-                    {
-                        "kadastraalOnroerendeZaken": [{
-                            "identificatie": "A6",
-                            "type": "appartementsrecht"
-                        }]
-                    }
-                ]
+                {
+                    "aard": {
+                        "code": "26",
+                        "waarde": "Ondersplitsing in appartementsrechten"
+                    },
+                    "kadastraalOnroerendeZaken": [{
+                        "identificatie": "A6",
+                        "type": "appartementsrecht"
+                    }]
+                }
                 """
             En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P10" ]
             En bevat het antwoord "volgnummer": 3
@@ -391,14 +395,16 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             Als "/kadastraalonroerendezaken/A9" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
-                [
-                    {
-                        "kadastraalOnroerendeZaken": [{
-                            "identificatie": "P12",
-                            "type": "perceel"
-                        }]
-                    }
-                ]
+                {
+                    "aard": {
+                        "code": "25",
+                        "waarde": "Splitsing in appartementsrechten"
+                    },
+                    "kadastraalOnroerendeZaken": [{
+                        "identificatie": "P12",
+                        "type": "perceel"
+                    }]
+                }
                 """
             En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P12" ]
             En bevat het antwoord in "bijbehorendeGrondperceelIdentificaties" geen waarde "P11"
@@ -420,14 +426,16 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             Als "/kadastraalonroerendezaken/A11" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
-                [
-                    {
-                        "kadastraalOnroerendeZaken": [{
-                            "identificatie": "P16",
-                            "type": "perceel"
-                        }]
-                    }
-                ]
+                {
+                    "aard": {
+                        "code": "25",
+                        "waarde": "Splitsing in appartementsrechten"
+                    },
+                    "kadastraalOnroerendeZaken": [{
+                        "identificatie": "P16",
+                        "type": "perceel"
+                    }]
+                }
                 """
             En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P16" ]
             En bevat het antwoord in "bijbehorendeGrondperceelIdentificaties" geen waarde "P14"
@@ -446,7 +454,7 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             En Appartementsrecht met identificatie "A13" is niet verder gesplitst of verenigd
             En Appartementsrecht met identificatie "A14" is ondergesplitst in appartementsrechten "A16" en "A17"
             En Appertementsrechten met identificatie "A15" en "A17" zijn samengevoegd (via wijzigingssplitsing)
-            En voor de wijzigingssplitsing zijn appartementsrechten "A13", "A14", "A15", "A16" en "A17" vervallen
+            En door de wijzigingssplitsing zijn appartementsrechten "A13", "A14", "A15", "A16" en "A17" vervallen
             En is appartementsrecht "A13" nieuw appartementsrecht "A18" geworden
             En is appartementsrecht "A16" nieuw appartementsrecht "A19" geworden
             En zijn appartementsrechten "A15" en "A17" nieuw appartementsrecht "A20" geworden
@@ -462,22 +470,24 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             Als "/kadastraalonroerendezaken/P17" wordt gevraagd
             Dan bevat het antwoord "isOvergegaanIn" met waarde:    
                 """
-                [
-                    {
-                        "kadastraalOnroerendeZaken": [
-                            {
-                                "identificatie": "A13",
-                                "type": "appartementsrecht"
-                            }, {
-                                "identificatie": "A14",
-                                "type": "appartementsrecht"
-                            }, {
-                                "identificatie": "A16",
-                                "type": "appartementsrecht"
-                            }
-                        ]
-                    }
-                ]
+                {
+                    "aard": {
+                        "code": "25",
+                        "waarde": "Splitsing in appartementsrechten"
+                    },
+                    "kadastraalOnroerendeZaken": [
+                        {
+                            "identificatie": "A13",
+                            "type": "appartementsrecht"
+                        }, {
+                            "identificatie": "A14",
+                            "type": "appartementsrecht"
+                        }, {
+                            "identificatie": "A16",
+                            "type": "appartementsrecht"
+                        }
+                    ]
+                }
                 """
             En bevat het antwoord "bijbehorendeAppartementsrechten" met waarde:    
                 """
@@ -512,7 +522,7 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             En Appartementsrecht met identificatie "A13" is niet verder gesplitst of verenigd
             En Appartementsrecht met identificatie "A14" is ondergesplitst in appartementsrechten "A16" en "A17"
             En Appertementsrechten met identificatie "A15" en "A17" zijn samengevoegd (via wijzigingssplitsing)
-            En voor de wijzigingssplitsing zijn appartementsrechten "A13", "A14", "A15", "A16" en "A17" vervallen
+            En door de wijzigingssplitsing zijn appartementsrechten "A13", "A14", "A15", "A16" en "A17" vervallen
             En is appartementsrecht "A13" nieuw appartementsrecht "A18" geworden
             En is appartementsrecht "A16" nieuw appartementsrecht "A19" geworden
             En zijn appartementsrechten "A15" en "A17" nieuw appartementsrecht "A20" geworden
@@ -522,8 +532,8 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             En Appartementsrecht met identificatie "A16" heeft "volgnummer"= 4
             En Appartementsrecht met identificatie "A17" heeft "volgnummer"= 5
             En Appartementsrecht met identificatie "A18" heeft "volgnummer"= 6
-            En Appartementsrecht met identificatie "A19" heeft "volgnummer"= 6
-            En Appartementsrecht met identificatie "A20" heeft "volgnummer"= 6
+            En Appartementsrecht met identificatie "A19" heeft "volgnummer"= 7
+            En Appartementsrecht met identificatie "A20" heeft "volgnummer"= 8
             En Appartementsrecht met identificatie "A18" is niet verder gesplitst of verenigd
             Als "/kadastraalonroerendezaken/A15" wordt gevraagd
             Dan geeft het antwoord http statuscode 410
@@ -545,25 +555,27 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             En Appartementsrecht met identificatie "A16" heeft "volgnummer"= 4
             En Appartementsrecht met identificatie "A17" heeft "volgnummer"= 5
             En Appartementsrecht met identificatie "A18" heeft "volgnummer"= 6
-            En Appartementsrecht met identificatie "A19" heeft "volgnummer"= 6
-            En Appartementsrecht met identificatie "A20" heeft "volgnummer"= 6
+            En Appartementsrecht met identificatie "A19" heeft "volgnummer"= 7
+            En Appartementsrecht met identificatie "A20" heeft "volgnummer"= 8
             En Appartementsrecht met identificatie "A18" is niet verder gesplitst of verenigd
             Als "/kadastraalonroerendezaken/A18" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
-                [
-                    {
-                        "kadastraalOnroerendeZaken": [
-                            {
-                                "identificatie": "A14",
-                                "type": "appartementsrecht"
-                            }, {
-                                "identificatie": "P17",
-                                "type": "perceel"
-                            }
-                        ]
-                    }
-                ]
+                {
+                    "aard": {
+                        "code": "28",
+                        "waarde": "Wijziging ondersplitsing m.b.t. appartementindices"
+                    },
+                    "kadastraalOnroerendeZaken": [
+                        {
+                            "identificatie": "A14",
+                            "type": "appartementsrecht"
+                        }, {
+                            "identificatie": "P17",
+                            "type": "perceel"
+                        }
+                    ]
+                }
                 """
             En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P17" ]
             En bevat het antwoord "volgnummer": 6
@@ -579,7 +591,7 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             En Appartementsrecht met identificatie "A13" is niet verder gesplitst of verenigd
             En Appartementsrecht met identificatie "A14" is ondergesplitst in appartementsrechten "A16" en "A17"
             En Appertementsrechten met identificatie "A15" en "A17" zijn samengevoegd (via wijzigingssplitsing)
-            En voor de wijzigingssplitsing zijn appartementsrechten "A13", "A14", "A15", "A16" en "A17" vervallen
+            En door de wijzigingssplitsing zijn appartementsrechten "A13", "A14", "A15", "A16" en "A17" vervallen
             En is appartementsrecht "A13" nieuw appartementsrecht "A18" geworden
             En is appartementsrecht "A16" nieuw appartementsrecht "A19" geworden
             En zijn appartementsrechten "A15" en "A17" nieuw appartementsrecht "A20" geworden
@@ -589,31 +601,35 @@ Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroe
             En Appartementsrecht met identificatie "A16" heeft "volgnummer"= 4
             En Appartementsrecht met identificatie "A17" heeft "volgnummer"= 5
             En Appartementsrecht met identificatie "A18" heeft "volgnummer"= 6
-            En Appartementsrecht met identificatie "A19" heeft "volgnummer"= 6
-            En Appartementsrecht met identificatie "A20" heeft "volgnummer"= 6
+            En Appartementsrecht met identificatie "A19" heeft "volgnummer"= 7
+            En Appartementsrecht met identificatie "A20" heeft "volgnummer"= 8
             En Appartementsrecht met identificatie "A18" is niet verder gesplitst of verenigd
             Als "/kadastraalonroerendezaken/A14" wordt gevraagd
             Dan bevat het antwoord "isOntstaanUit" met waarde:    
                 """
-                [
-                    {
-                        "kadastraalOnroerendeZaken": [{
-                            "identificatie": "P17",
-                            "type": "perceel"
-                        }]
-                    }
-                ]
+                {
+                    "aard": {
+                        "code": "25",
+                        "waarde": "Splitsing in appartementsrechten"
+                    },
+                    "kadastraalOnroerendeZaken": [{
+                        "identificatie": "P17",
+                        "type": "perceel"
+                    }]
+                }
                 """
             En bevat het antwoord "isOvergegaanIn" met waarde:    
                 """
-                [
-                    {
-                        "kadastraalOnroerendeZaken": [{
-                            "identificatie": "A16",
-                            "type": "appartementsrecht"
-                        }]
-                    }
-                ]
+                {
+                    "aard": {
+                        "code": "26",
+                        "waarde": "Ondersplitsing in appartementsrechten"
+                    },
+                    "kadastraalOnroerendeZaken": [{
+                        "identificatie": "A16",
+                        "type": "appartementsrecht"
+                    }]
+                }
                 """
             En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P17" ]
             En bevat het antwoord "volgnummer": 2

--- a/features/filiatie.feature
+++ b/features/filiatie.feature
@@ -1,0 +1,470 @@
+# language: nl
+
+Functionaliteit: Als gemeente wil ik inzicht in de filiatie van Kadastraal onroerende zaken
+
+    #TODO: invullen onroerende zaak identificaties
+
+    Achtergrond:
+        Gegeven Perceel met identificatie "P1" is gesplitst naar percelen "P2" en "P3"
+        En Perceel met identificatie "P1" is niet ontstaan uit splitsing of vereniging van een ander perceel
+        En Perceel met identificatie "P2" is niet verder gesplitst of verenigd
+        En Perceel met identificatie "P3" is niet verder gesplitst of verenigd
+
+        En Percelen met identificatie "P4" en "P5" zijn verenigd naar perceel "P6"
+        En Perceel met identificatie "P4" is niet ontstaan uit splitsing of vereniging van een ander perceel
+        En Perceel met identificatie "P5" is niet ontstaan uit splitsing of vereniging van een ander perceel
+        En Perceel met identificatie "P6" is niet verder gesplitst of verenigd
+
+        En Perceel met identificatie "P7" is gesplitst naar appartementsrechten "A1" en "A2"
+        En Perceel met identificatie "P7" is niet ontstaan uit splitsing of vereniging van een ander perceel
+        En Appartementsrecht met identificatie "A1" is niet verder gesplitst of verenigd
+        En Appartementsrecht met identificatie "A1" heeft "appartementsrechtVolgnummer"= 1
+        En Appartementsrecht met identificatie "A2" is niet verder gesplitst of verenigd
+        En Appartementsrecht met identificatie "A2" heeft "appartementsrechtVolgnummer"= 2
+
+        En Percelen met identificatie "P8" en "P9" zijn gesplitst naar appartementsrechten "A3" en "A4"
+        En Perceel met identificatie "P8" is niet ontstaan uit splitsing of vereniging van een ander perceel
+        En Perceel met identificatie "P9" is niet ontstaan uit splitsing of vereniging van een ander perceel
+        En Appartementsrecht met identificatie "A3" is niet verder gesplitst of verenigd
+        En Appartementsrecht met identificatie "A3" heeft "appartementsrechtVolgnummer"= 1
+        En Appartementsrecht met identificatie "A4" is niet verder gesplitst of verenigd
+        En Appartementsrecht met identificatie "A4" heeft "appartementsrechtVolgnummer"= 2
+
+        En Perceel met identificatie "P10" is gesplitst naar appartementsrechten "A5" en "A6"
+        En Perceel met identificatie "P10" is niet ontstaan uit splitsing of vereniging van een ander perceel
+        En Appartementsrecht met identificatie "A5" is niet verder gesplitst of verenigd
+        En Appartementsrecht met identificatie "A5" heeft "appartementsrechtVolgnummer"= 1
+        En Appartementsrecht met identificatie "A6" is ondergesplitst in appartementsrechten "A7" en "A8"
+        En Appartementsrecht met identificatie "A6" heeft "appartementsrechtVolgnummer"= 2
+        En Appartementsrecht met identificatie "A7" heeft "appartementsrechtVolgnummer"= 3
+        En Appartementsrecht met identificatie "A8" heeft "appartementsrechtVolgnummer"= 4
+
+        En Perceel met identificatie "P11" is gesplitst naar percelen "P12" en "P13"
+        En Perceel met identificatie "P12" is gesplitst naar appartementsrechten "A9" en "A10"
+        En Appartementsrecht met identificatie "A9" is niet verder gesplitst of verenigd
+        En Appartementsrecht met identificatie "A9" heeft "appartementsrechtVolgnummer"= 1
+        En Appartementsrecht met identificatie "A10" is niet verder gesplitst of verenigd
+        En Appartementsrecht met identificatie "A10" heeft "appartementsrechtVolgnummer"= 2
+
+        En Percelen met identificatie "P14" en "P15" zijn verenigd naar perceel "P16"
+        En Perceel met identificatie "P16" is gesplitst naar appartementsrechten "A11" en "A12"
+        En Appartementsrecht met identificatie "A11" is niet verder gesplitst of verenigd
+        En Appartementsrecht met identificatie "A11" heeft "appartementsrechtVolgnummer"= 1
+        En Appartementsrecht met identificatie "A12" is niet verder gesplitst of verenigd
+        En Appartementsrecht met identificatie "A12" heeft "appartementsrechtVolgnummer"= 2
+
+        En Perceel met identificatie "P17" is gesplitst naar appartementsrechten "A13", "A14" en "A15"
+        En Perceel met identificatie "P17" is niet ontstaan uit splitsing of vereniging van een ander perceel
+        En Appartementsrecht met identificatie "A13" is niet verder gesplitst of verenigd
+        En Appartementsrecht met identificatie "A14" is ondergesplitst in appartementsrechten "A16" en "A17"
+        En Appertementsrechten met identificatie "A15" en "A17" zijn samengevoegd (via wijzigingssplitsing)
+        En voor de wijzigingssplitsing zijn appartementsrechten "A13", "A14", "A15", "A16" en "A17" vervallen
+        En is appartementsrecht "A13" nieuw appartementsrecht "A18" geworden
+        En is appartementsrecht "A16" nieuw appartementsrecht "A19" geworden
+        En zijn appartementsrechten "A15" en "A17" nieuw appartementsrecht "A20" geworden
+        En Appartementsrecht met identificatie "A13" heeft "appartementsrechtVolgnummer"= 1
+        En Appartementsrecht met identificatie "A14" heeft "appartementsrechtVolgnummer"= 2
+        En Appartementsrecht met identificatie "A15" heeft "appartementsrechtVolgnummer"= 3
+        En Appartementsrecht met identificatie "A16" heeft "appartementsrechtVolgnummer"= 4
+        En Appartementsrecht met identificatie "A17" heeft "appartementsrechtVolgnummer"= 5
+        En Appartementsrecht met identificatie "A18" heeft "appartementsrechtVolgnummer"= 6
+        En Appartementsrecht met identificatie "A19" heeft "appartementsrechtVolgnummer"= 6
+        En Appartementsrecht met identificatie "A20" heeft "appartementsrechtVolgnummer"= 6
+        En Appartementsrecht met identificatie "A18" is niet verder gesplitst of verenigd
+
+
+    Rule: Na splitsing van een perceel wordt filiatie getoond bij het vervallen perceel en bij de nieuwe percelen
+        Scenario: Opvragen van een vervallen perceel na splitsing
+            Als "/kadastraalonroerendezaken/P1" wordt gevraagd
+            Dan bevat het antwoord "isOvergegaanIn" met waarde:    
+                """
+                [
+                    {
+                        "aard": {
+                            "code": "20",
+                            "waarde": "Splitsen perceel"
+                        },
+                        "identificatie": "P2"
+                    },
+                    {
+                        "aard": {
+                            "code": "20",
+                            "waarde": "Splitsen perceel"
+                        },
+                        "identificatie": "P3"
+                    }
+                ]
+                """
+            En bevat het antwoord "indicatieVervallen": true
+            En bevat het antwoord property "einddatum" met een waarde
+            En bevat het antwoord geen property "indicatieSluimerend"
+            En bevat het antwoord geen property "bijbehorendeGrondperceelIdentificaties"
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+
+        Scenario: Opvragen perceel uit splitsing
+            Als "/kadastraalonroerendezaken/P2" wordt gevraagd
+            Dan bevat het antwoord "isOntstaanUit" met waarde:    
+                """
+                [
+                    {
+                        "aard": {
+                            "code": "20",
+                            "waarde": "Splitsen perceel"
+                        },
+                        "identificatie": "P1"
+                    }
+                ]
+                """
+            En bevat het antwoord geen property "indicatieVervallen"
+            En bevat het antwoord geen property "einddatum"
+            En bevat het antwoord geen property "indicatieSluimerend"
+            En bevat het antwoord geen property "isOvergegaanIn"
+            En bevat het antwoord geen property "bijbehorendeGrondperceelIdentificaties"
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+    
+    Rule: Na vereniging van percelen wordt filiatie getoond bij de vervallen percelen en bij het nieuwe perceel
+        Scenario: Opvragen vervallen perceel na vereniging
+            Als "/kadastraalonroerendezaken/P4" wordt gevraagd
+            Dan bevat het antwoord "isOvergegaanIn" met waarde:    
+                """
+                [
+                    {
+                        "aard": {
+                            "code": "19",
+                            "waarde": "Verenigen percelen"
+                        },
+                        "identificatie": "P6"
+                    }
+                ]
+                """
+            En bevat het antwoord "indicatieVervallen": true
+            En bevat het antwoord property "einddatum" met een waarde
+            En bevat het antwoord geen property "indicatieSluimerend"
+            En bevat het antwoord geen property "bijbehorendeGrondperceelIdentificaties"
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+
+        Scenario: Opvragen perceel uit vereniging
+            Als "/kadastraalonroerendezaken/P6" wordt gevraagd
+            Dan bevat het antwoord "isOntstaanUit" met waarde:    
+                """
+                [
+                    {
+                        "aard": {
+                            "code": "19",
+                            "waarde": "Verenigen percelen"
+                        },
+                        "identificatie": "P4"
+                    },
+                    {
+                        "aard": {
+                            "code": "19",
+                            "waarde": "Verenigen percelen"
+                        },
+                        "identificatie": "P5"
+                    }
+                ]
+                """
+            En bevat het antwoord geen property "indicatieVervallen"
+            En bevat het antwoord geen property "einddatum"
+            En bevat het antwoord geen property "indicatieSluimerend"
+            En bevat het antwoord geen property "isOvergegaanIn"
+            En bevat het antwoord geen property "bijbehorendeGrondperceelIdentificaties"
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+
+    Rule: Splitsing in appartementsrechten van een perceel toont verwijzingen van het grondperceel naar de appartementsrechten en vice versa
+        Scenario: Opvragen van het grondperceel na splitsing in appartementsrechten
+            Als "/kadastraalonroerendezaken/P7" wordt gevraagd
+            Dan bevat het antwoord "isOvergegaanIn" met waarde:    
+                """
+                [
+                    {
+                        "identificatie": "A1"
+                    },
+                    {
+                        "identificatie": "A2"
+                    }
+                ]
+                """
+            En bevat het antwoord "bijbehorendeAppartementsrechtIdentificaties" met waarde:    
+                """
+                [
+                    {
+                        "identificatie": "A1",
+                        "appartementsrechtVolgnummer": 1
+                    },
+                    {
+                        "identificatie": "A2",
+                        "appartementsrechtVolgnummer": 1
+                    }
+                ]
+                """
+            En bevat het antwoord geen property "indicatieVervallen"
+            En bevat het antwoord geen property "einddatum"
+            En bevat het antwoord geen property "indicatieSluimerend"
+            En bevat het antwoord geen property "appartementsrechtVolgnummer"
+            En bevat het antwoord geen property "bijbehorendeGrondperceelIdentificaties"
+
+        Scenario: Opvragen appartementsrecht uit splitsing
+            Als "/kadastraalonroerendezaken/A1" wordt gevraagd
+            Dan bevat het antwoord "isOntstaanUit" met waarde:    
+                """
+                [
+                    {
+                        "identificatie": "P7"
+                    }
+                ]
+                """
+            En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P7" ]
+            En bevat het antwoord "appartementsrechtVolgnummer": 1
+            En bevat het antwoord geen property "indicatieVervallen"
+            En bevat het antwoord geen property "einddatum"
+            En bevat het antwoord geen property "indicatieSluimerend"
+            En bevat het antwoord geen property "isOvergegaanIn"
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+
+        Scenario: Opvragen appartementsrecht met meerdere bijbehorende grondpercelen
+            Als "/kadastraalonroerendezaken/A3" wordt gevraagd
+            Dan bevat het antwoord "isOntstaanUit" met waarde:    
+                """
+                [
+                    {
+                        "identificatie": "P8"
+                    },
+                    {
+                        "identificatie": "P9"
+                    }
+                ]
+                """
+            En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P8", "P9" ]
+            En bevat het antwoord "appartementsrechtVolgnummer": 1
+            En bevat het antwoord geen property "indicatieVervallen"
+            En bevat het antwoord geen property "einddatum"
+            En bevat het antwoord geen property "indicatieSluimerend"
+            En bevat het antwoord geen property "isOvergegaanIn"
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+
+    Rule: Bij ondersplitsing van een appartementsrecht worden alle bijbehorende appartementsrechten getoond bij het perceel en wordt indicatieSluimerend getoond bij het sluimerende appartementsrecht
+        Scenario: Opvragen van het grondperceel na splitsing in appartementsrechten en ondersplitsing van een appartementsrecht
+            Als "/kadastraalonroerendezaken/P10" wordt gevraagd
+            Dan bevat het antwoord "isOvergegaanIn" met waarde:    
+                """
+                [
+                    {
+                        "identificatie": "A5"
+                    },
+                    {
+                        "identificatie": "A6"
+                    }
+                ]
+                """
+            En bevat het antwoord "bijbehorendeAppartementsrechtIdentificaties" met waarde:    
+                """
+                [
+                    {
+                        "identificatie": "A5",
+                        "appartementsrechtVolgnummer": 1
+                    },
+                    {
+                        "identificatie": "A6",
+                        "appartementsrechtVolgnummer": 2,
+                        "indicatieSluimerend": true
+                    },
+                    {
+                        "identificatie": "A7",
+                        "appartementsrechtVolgnummer": 3
+                    },
+                    {
+                        "identificatie": "A8",
+                        "appartementsrechtVolgnummer": 4
+                    }
+                ]
+                """
+            En bevat het antwoord geen property "indicatieVervallen"
+            En bevat het antwoord geen property "einddatum"
+            En bevat het antwoord geen property "indicatieSluimerend"
+            En bevat het antwoord geen property "appartementsrechtVolgnummer"
+            En bevat het antwoord geen property "bijbehorendeGrondperceelIdentificaties"
+
+    Rule: Na ondersplitsing van een appartementsrecht toont de filiatie één stap omhoog of omlaag, plus het bijbehorende grondperceel
+        Scenario: Opvragen sluimerend appartementsrecht na ondersplitsing
+            Als "/kadastraalonroerendezaken/A6" wordt gevraagd
+            Dan bevat het antwoord "isOntstaanUit" met waarde:    
+                """
+                [
+                    {
+                        "identificatie": "P10"
+                    }
+                ]
+                """
+            En bevat het antwoord "isOvergegaanIn" met waarde:    
+                """
+                [
+                    {
+                        "identificatie": "A7"
+                    },
+                    {
+                        "identificatie": "A8"
+                    }
+                ]
+                """
+            En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P10" ]
+            En bevat het antwoord "appartementsrechtVolgnummer": 2
+            En bevat het antwoord geen property "indicatieVervallen"
+            En bevat het antwoord geen property "einddatum"
+            En bevat het antwoord "indicatieSluimerend": true
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+
+        Scenario: Opvragen appartementsrecht uit ondersplitsing
+            Als "/kadastraalonroerendezaken/A7" wordt gevraagd
+            Dan bevat het antwoord "isOntstaanUit" met waarde:    
+                """
+                [
+                    {
+                        "identificatie": "A6"
+                    }
+                ]
+                """
+            En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P10" ]
+            En bevat het antwoord "appartementsrechtVolgnummer": 3
+            En bevat het antwoord geen property "indicatieVervallen"
+            En bevat het antwoord geen property "einddatum"
+            En bevat het antwoord geen property "indicatieSluimerend"
+            En bevat het antwoord geen property "isOvergegaanIn"
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+
+    Rule: Een vervallen (verenigd of gesplitst) perceel wordt niet getoond als bijbehorend grondperceel 
+        Scenario: Opvragen appartementsrecht met grondperceel uit splitsing
+            Als "/kadastraalonroerendezaken/A9" wordt gevraagd
+            Dan bevat het antwoord "isOntstaanUit" met waarde:    
+                """
+                [
+                    {
+                        "identificatie": "P12"
+                    }
+                ]
+                """
+            En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P12" ]
+            En bevat het antwoord in "bijbehorendeGrondperceelIdentificaties" geen waarde "P11"
+            En bevat het antwoord in "bijbehorendeGrondperceelIdentificaties" geen waarde "P13"
+            En bevat het antwoord "appartementsrechtVolgnummer": 1
+            En bevat het antwoord geen property "indicatieVervallen"
+            En bevat het antwoord geen property "einddatum"
+            En bevat het antwoord geen property "indicatieSluimerend"
+            En bevat het antwoord geen property "isOvergegaanIn"
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+
+        Scenario: Opvragen appartementsrecht met grondperceel uit vereniging
+            Als "/kadastraalonroerendezaken/A11" wordt gevraagd
+            Dan bevat het antwoord "isOntstaanUit" met waarde:    
+                """
+                [
+                    {
+                        "identificatie": "P16"
+                    }
+                ]
+                """
+            En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P16" ]
+            En bevat het antwoord in "bijbehorendeGrondperceelIdentificaties" geen waarde "P14"
+            En bevat het antwoord in "bijbehorendeGrondperceelIdentificaties" geen waarde "P15"
+            En bevat het antwoord "appartementsrechtVolgnummer": 1
+            En bevat het antwoord geen property "indicatieVervallen"
+            En bevat het antwoord geen property "einddatum"
+            En bevat het antwoord geen property "indicatieSluimerend"
+            En bevat het antwoord geen property "isOvergegaanIn"
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+    
+    Rule: Na een wijzigingssplitsing van een appartementsrecht worden de vervallen appartementsrechten niet getoond en wordt de filiatie uit het oude appartementsrecht overgenomen in de nieuwe appartementsrechten
+        Scenario: Opvragen van het grondperceel na wijzigingssplitsing van appartementsrechten
+            Als "/kadastraalonroerendezaken/P17" wordt gevraagd
+            Dan bevat het antwoord "isOvergegaanIn" met waarde:    
+                """
+                [
+                    {
+                        "identificatie": "A13"
+                    },
+                    {
+                        "identificatie": "A14"
+                    },
+                    {
+                        "identificatie": "A16"
+                    }
+                ]
+                """
+            En bevat het antwoord "bijbehorendeAppartementsrechtIdentificaties" met waarde:    
+                """
+                [
+                    {
+                        "identificatie": "A13",
+                        "appartementsrechtVolgnummer": 1
+                    },
+                    {
+                        "identificatie": "A14",
+                        "appartementsrechtVolgnummer": 2,
+                        "indicatieSluimerend": true
+                    },
+                    {
+                        "identificatie": "A16",
+                        "appartementsrechtVolgnummer": 4
+                    },
+                    {
+                        "identificatie": "A18",
+                        "appartementsrechtVolgnummer": 6
+                    }
+                ]
+                """
+            En bevat het antwoord geen property "indicatieVervallen"
+            En bevat het antwoord geen property "einddatum"
+            En bevat het antwoord geen property "indicatieSluimerend"
+            En bevat het antwoord geen property "appartementsrechtVolgnummer"
+            En bevat het antwoord geen property "bijbehorendeGrondperceelIdentificaties"
+
+        Scenario: Opvragen van een vervallen appartementsrecht
+            Als "/kadastraalonroerendezaken/A15" wordt gevraagd
+            Dan geeft het antwoord http statuscode 410
+            En bevat het antwoord "detail": "Dit appartementsrecht is vervallen en is overgegaan in appartementsrecht A18"
+
+        Scenario: opvragen van appartementsrecht na wijzigingssplitsing
+            Als "/kadastraalonroerendezaken/A18" wordt gevraagd
+            Dan bevat het antwoord "isOntstaanUit" met waarde:    
+                """
+                [
+                    {
+                        "identificatie": "A14",
+                    },
+                    {
+                        "identificatie": "P17"
+                    }
+                ]
+                """
+            En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P17" ]
+            En bevat het antwoord "appartementsrechtVolgnummer": 6
+            En bevat het antwoord geen property "indicatieVervallen"
+            En bevat het antwoord geen property "einddatum"
+            En bevat het antwoord geen property "indicatieSluimerend"
+            En bevat het antwoord geen property "isOvergegaanIn"
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"
+
+        Scenario: opvragen van sluimerend appartementsrecht na wijzigingssplitsing in gesplitst perceel
+            Als "/kadastraalonroerendezaken/A14" wordt gevraagd
+            Dan bevat het antwoord "isOntstaanUit" met waarde:    
+                """
+                [
+                    {
+                        "identificatie": "P17"
+                    }
+                ]
+                """
+            En bevat het antwoord "isOvergegaanIn" met waarde:    
+                """
+                [
+                    {
+                        "identificatie": "A16"
+                    }
+                ]
+                """
+            En bevat het antwoord "bijbehorendeGrondperceelIdentificaties": [ "P17" ]
+            En bevat het antwoord "appartementsrechtVolgnummer": 2
+            En bevat het antwoord geen property "indicatieVervallen"
+            En bevat het antwoord geen property "einddatum"
+            En bevat het antwoord "indicatieSluimerend": true
+            En bevat het antwoord geen property "bijbehorendeAppartementsrechtIdentificaties"


### PR DESCRIPTION
Feature die het opnemen van de filiatie gegevens illustreert.

Deze versie heeft nog:
- geen onroerende zaak identificaties ingevuld, ik hoop hiervoor binnenkort onroerende zaken te vinden in de acceptatie omgeving
- wel indicatieSluimerend in bijbehorendeAppartementsrechtIdentificaties, maar @kad-pothot heeft aangegeven dat dit in release v1.3 nog niet kan worden geleverd