### PR TITLE
Queryparameter kadastraleAanduidingMetGemeentecode toegevoegd

### DIFF
--- a/specificatie/kadastraal-onroerende-zaken.yaml
+++ b/specificatie/kadastraal-onroerende-zaken.yaml
@@ -26,6 +26,8 @@ paths:
               -  huisnummertoevoeging (optioneel)
           5.  Nummeraanduiding
               - nummeraanduidingIdentificatie
+          6.1.  Kadastrale aanduiding mry gemeentecode
+              - kadastraleAanduidingMetGemeentecode
 
           Met gebruik van de parameter expand kunnen zakelijkGerechtigden en privaatrechtelijkeBeperkingen direct worden meegeladen.
 
@@ -54,22 +56,6 @@ paths:
             type: "string"
             pattern: "^([a-zA-Z0-9'][a-zA-Z0-9' ,-]*[a-zA-Z0-9]) ([A-IK-Z]{1,2}) ([1-9][0-9]{0,4})( A[1-9][0-9]{0,3})?$"
             example: "'s Gravenhage C 1277 A3"
-        - in: query
-          name: kadastraleAanduidingMetGemeentecode
-          description: |
-                        Kadastrale aanduiding is in sommige domeinen opgeslagen met de gemeentecode in plaats van de gemeentenaam.
-                        Dit is een unieke aanduiding van een onroerende zaak. De volgorde waarin deze string wordt opgebouwd is
-
-                        - gemeentecode van de kadastrale gemeente(http://www.kadaster.nl/schemas/waardelijsten/KadastraleGemeente/).
-
-                        - sectie, 1 of 2 hoofdletters
-
-                        - perceelnummer, 1 tot 5 cijfers
-
-                        - appartementsrechtVolgnummer, Hoofdletter A gevolgd door 1 tot 4 cijfers (optioneel)
-
-
-                        gescheiden door een spatie"
           schema:
             type: "string"
             pattern: "^([A-Z]{3}[0-9]{2}) ([A-IK-Z]{1,2}) ([1-9][0-9]{0,4})( A[1-9][0-9]{0,3})?$"
@@ -137,6 +123,22 @@ paths:
           schema:
             type: string
             pattern: "^[0-9]{16}$"
+        - in: query
+          name: kadastraleAanduidingMetGemeentecode
+          description: |
+                        Kadastrale aanduiding is in sommige domeinen opgeslagen met de gemeentecode in plaats van de gemeentenaam.
+                        Dit is een unieke aanduiding van een onroerende zaak. De volgorde waarin deze string wordt opgebouwd is
+
+                        - [Gemeentecode van de kadastrale gemeente](http://www.kadaster.nl/schemas/waardelijsten/KadastraleGemeente/).
+
+                        - sectie, 1 of 2 hoofdletters
+
+                        - perceelnummer, 1 tot 5 cijfers
+
+                        - appartementsrechtVolgnummer, Hoofdletter A gevolgd door 1 tot 4 cijfers (optioneel)
+
+
+                        gescheiden door een spatie"
       responses:
         '200':
           description: |

--- a/specificatie/kadastraal-onroerende-zaken.yaml
+++ b/specificatie/kadastraal-onroerende-zaken.yaml
@@ -55,6 +55,26 @@ paths:
             pattern: "^([a-zA-Z0-9'][a-zA-Z0-9' ,-]*[a-zA-Z0-9]) ([A-IK-Z]{1,2}) ([1-9][0-9]{0,4})( A[1-9][0-9]{0,3})?$"
             example: "'s Gravenhage C 1277 A3"
         - in: query
+          name: kadastraleAanduidingMetGemeentecode
+          description: |
+                        Kadastrale aanduiding is in sommige domeinen opgeslagen met de gemeentecode in plaats van de gemeentenaam.
+                        Dit is een unieke aanduiding van een onroerende zaak. De volgorde waarin deze string wordt opgebouwd is
+
+                        - gemeentecode van de kadastrale gemeente(http://www.kadaster.nl/schemas/waardelijsten/KadastraleGemeente/).
+
+                        - sectie, 1 of 2 hoofdletters
+
+                        - perceelnummer, 1 tot 5 cijfers
+
+                        - appartementsrechtVolgnummer, Hoofdletter A gevolgd door 1 tot 4 cijfers (optioneel)
+
+
+                        gescheiden door een spatie"
+          schema:
+            type: "string"
+            pattern: "^([A-Z]{3}[0-9]{2}) ([A-IK-Z]{1,2}) ([1-9][0-9]{0,4})( A[1-9][0-9]{0,3})?$"
+            example: "GVH00 C 1277 A3"
+        - in: query
           name: burgerservicenummer
           description: |
                         Het burgerservicenummer van de persoon die een zakelijk recht op een kadastraal onroerende zaak heeft. Deze persoon is zakelijk gerechtigde van de kadastraal onroerende zaak. Door deze query-parameter te gebruiken worden Kadastraal Onroerende Zaken geretourneerd waar deze persoon een zakelijk recht op heeft.

--- a/specificatie/kadastraal-onroerende-zaken.yaml
+++ b/specificatie/kadastraal-onroerende-zaken.yaml
@@ -26,7 +26,7 @@ paths:
               -  huisnummertoevoeging (optioneel)
           5.  Nummeraanduiding
               - nummeraanduidingIdentificatie
-          6.1.  Kadastrale aanduiding mry gemeentecode
+          6.  Kadastrale aanduiding met gemeentecode
               - kadastraleAanduidingMetGemeentecode
 
           Met gebruik van de parameter expand kunnen zakelijkGerechtigden en privaatrechtelijkeBeperkingen direct worden meegeladen.
@@ -56,10 +56,6 @@ paths:
             type: "string"
             pattern: "^([a-zA-Z0-9'][a-zA-Z0-9' ,-]*[a-zA-Z0-9]) ([A-IK-Z]{1,2}) ([1-9][0-9]{0,4})( A[1-9][0-9]{0,3})?$"
             example: "'s Gravenhage C 1277 A3"
-          schema:
-            type: "string"
-            pattern: "^([A-Z]{3}[0-9]{2}) ([A-IK-Z]{1,2}) ([1-9][0-9]{0,4})( A[1-9][0-9]{0,3})?$"
-            example: "GVH00 C 1277 A3"
         - in: query
           name: burgerservicenummer
           description: |
@@ -139,6 +135,10 @@ paths:
 
 
                         gescheiden door een spatie"
+          schema:
+            type: "string"
+            pattern: "^([A-Z]{3}[0-9]{2}) ([A-IK-Z]{1,2}) ([1-9][0-9]{0,4})( A[1-9][0-9]{0,3})?$"
+            example: "GVH00 C 1277 A3"
       responses:
         '200':
           description: |


### PR DESCRIPTION
Vraag: Ik heb alleen de query-parameter toegevoegd. Volgens mij willen we niet dat we deze aanduiding met gemeentecode ook toevoegen aan de resource KadastraalOnroerendeZaak. Dat wil ik even checken. 