### PR TITLE
Zakelijkgerechtigden n.a.v. splitsingen.  Aanpassing zoals vorige week woensdag besproken doorgevoerd

### DIFF
--- a/specificatie/domain.yaml
+++ b/specificatie/domain.yaml
@@ -1108,7 +1108,7 @@ components:
           $ref: "#/components/schemas/PersoonBeperkt"
         indicatieGerechtigdUitSplitsing:
           type: "boolean"
-          description: "Geeft aan of dit zakelijk gerechtigde is met een recht is dat onstaan is uit splitsing van een ander recht"
+          description: "Geeft aan of dit een zakelijk gerechtigde is met een recht dat ontstaan is uit splitsing van een ander recht"
         appartementsrechtUitSplitsingIdentificatie:
           type: "string"
           description: "Identificatie van het appartementsrecht waar het gesplitste recht betrekking op heeft"

--- a/specificatie/domain.yaml
+++ b/specificatie/domain.yaml
@@ -1108,7 +1108,7 @@ components:
           $ref: "#/components/schemas/PersoonBeperkt"
         indicatieGerechtigdUitSplitsing:
           type: "boolean"
-          description: "Geeft aan of dit zakelijk gerechtigde is met een recht is dat onstaan is uit splisting van een ander recht"
+          description: "Geeft aan of dit zakelijk gerechtigde is met een recht is dat onstaan is uit splitsing van een ander recht"
         appartementsrechtUitSplitsingIdentificatie:
           type: "string"
           description: "Identificatie van het appartementsrecht waar het gesplitste recht betrekking op heeft"

--- a/specificatie/domain.yaml
+++ b/specificatie/domain.yaml
@@ -1106,6 +1106,12 @@ components:
           $ref: "#/components/schemas/ZakelijkRecht"
         persoon:
           $ref: "#/components/schemas/PersoonBeperkt"
+        indicatieGerechtigdUitSplitsing:
+          type: "boolean"
+          description: "Geeft aan of dit zakelijk gerechtigde is met een recht is dat onstaan is uit splisting van een ander recht"
+        appartementsrechtUitSplitsingIdentificatie:
+          type: "string"
+          description: "Identificatie van het appartementsrecht waar het gesplitste recht betrekking op heeft"
     ZakelijkRecht:
       type: object
       properties:

--- a/specificatie/domain.yaml
+++ b/specificatie/domain.yaml
@@ -1093,6 +1093,8 @@ components:
                         Identificatie van de zakelijk gerechtigde.
         type:
           $ref: "#/components/schemas/TypeGerechtigdeEnum"
+        gesplitstZakelijkRecht:
+          $ref: "#/components/schemas/TypeGerechtigdeEnum"
         aanvangsdatum:
           type: "string"
           description: |
@@ -1106,12 +1108,6 @@ components:
           $ref: "#/components/schemas/ZakelijkRecht"
         persoon:
           $ref: "#/components/schemas/PersoonBeperkt"
-        indicatieGerechtigdUitSplitsing:
-          type: "boolean"
-          description: "Geeft aan of dit een zakelijk gerechtigde is met een recht dat ontstaan is uit splitsing van een ander recht"
-        appartementsrechtUitSplitsingIdentificatie:
-          type: "string"
-          description: "Identificatie van het appartementsrecht waar het gesplitste recht betrekking op heeft"
     ZakelijkRecht:
       type: object
       properties:

--- a/specificatie/zakelijk-gerechtigden.yaml
+++ b/specificatie/zakelijk-gerechtigden.yaml
@@ -81,7 +81,7 @@ paths:
             $ref: "domain.yaml#/components/schemas/TypeGerechtigdeEnum"
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/parameters/acceptCrs"
         - in: query
-          name: inclusiefUitsplitsing
+          name: inclusiefUitSplitsing
           description: |
                         Geeft aan of de gerelateerde zakelijk gerechtigden n.a.v. splitsingen van recht ook getoond moeten worden.
           required: false
@@ -162,7 +162,7 @@ components:
     ZakelijkGerechtigdeHalCollectieEmbedded:
       type: "object"
       properties:
-        zakelijkGerechtigdenUitSplitsing:
+        indicatieZakelijkGerechtigdenUitSplitsing:
           type: "boolean"
           description: "Geeft aan of er n.a.v. splitsingen van het zakelijk recht nog andere gerelateerde zakelijkgerechtigden zijn"
         zakelijkGerechtigden:

--- a/specificatie/zakelijk-gerechtigden.yaml
+++ b/specificatie/zakelijk-gerechtigden.yaml
@@ -80,13 +80,6 @@ paths:
           schema:
             $ref: "domain.yaml#/components/schemas/TypeGerechtigdeEnum"
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/parameters/acceptCrs"
-        - in: query
-          name: inclusiefUitSplitsing
-          description: |
-                        Geeft aan of de gerelateerde zakelijk gerechtigden n.a.v. splitsingen van recht ook getoond moeten worden.
-          required: false
-          schema:
-            type: "boolean"
       responses:
         '200':
           description: |
@@ -148,23 +141,24 @@ components:
           type: "array"
           items:
             $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
-        zakelijkGerechtigdenUitSplitsing:
-          type: "array"
-          items:
-            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
     ZakelijkGerechtigdeHalCollectie:
       type: "object"
       properties:
         _links:
-          $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalCollectionLinks"
+          self:
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+          kadastraalOnroerendeZakenUitSplitsing:
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+          kadastraalOnroerendeZakenUitSplitsingInclusiefZakelijkGerechtigden:
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
         _embedded:
             $ref: "#/components/schemas/ZakelijkGerechtigdeHalCollectieEmbedded"
+        gesplitstZakelijkRecht:
+          type: "string"
+          description: "Geeft aan welk type zakelijk recht gespiltst is."
     ZakelijkGerechtigdeHalCollectieEmbedded:
       type: "object"
       properties:
-        indicatieZakelijkGerechtigdenUitSplitsing:
-          type: "boolean"
-          description: "Geeft aan of er n.a.v. splitsingen van het zakelijk recht nog andere gerelateerde zakelijkgerechtigden zijn"
         zakelijkGerechtigden:
           type: "array"
           items:

--- a/specificatie/zakelijk-gerechtigden.yaml
+++ b/specificatie/zakelijk-gerechtigden.yaml
@@ -86,7 +86,7 @@ paths:
                         Geeft aan of de gerelateerde zakelijk gerechtigden n.a.v. splitsingen van recht ook getoond moeten worden.
           required: false
           schema:
-            inclusiefUitsplitsing: "boolean"
+            type: "boolean"
       responses:
         '200':
           description: |

--- a/specificatie/zakelijk-gerechtigden.yaml
+++ b/specificatie/zakelijk-gerechtigden.yaml
@@ -81,7 +81,7 @@ paths:
             $ref: "domain.yaml#/components/schemas/TypeGerechtigdeEnum"
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/parameters/acceptCrs"
         - in: query
-          name: type
+          name: inclusiefUitsplitsing
           description: |
                         Geeft aan of de gerelateerde zakelijk gerechtigden n.a.v. splitsingen van recht ook getoond moeten worden.
           required: false

--- a/specificatie/zakelijk-gerechtigden.yaml
+++ b/specificatie/zakelijk-gerechtigden.yaml
@@ -80,6 +80,13 @@ paths:
           schema:
             $ref: "domain.yaml#/components/schemas/TypeGerechtigdeEnum"
         - $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/parameters/acceptCrs"
+        - in: query
+          name: type
+          description: |
+                        Geeft aan of de gerelateerde zakelijk gerechtigden n.a.v. splitsingen van recht ook getoond moeten worden.
+          required: false
+          schema:
+            inclusiefUitsplitsing: "boolean"
       responses:
         '200':
           description: |
@@ -141,6 +148,10 @@ components:
           type: "array"
           items:
             $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
+        zakelijkGerechtigdenUitSplitsing:
+          type: "array"
+          items:
+            $ref: "https://raw.githubusercontent.com/VNG-Realisatie/Haal-Centraal-common/v1.2.0/api-specificatie/common.yaml#/components/schemas/HalLink"
     ZakelijkGerechtigdeHalCollectie:
       type: "object"
       properties:
@@ -151,6 +162,9 @@ components:
     ZakelijkGerechtigdeHalCollectieEmbedded:
       type: "object"
       properties:
+        zakelijkGerechtigdenUitSplitsing:
+          type: "boolean"
+          description: "Geeft aan of er n.a.v. splitsingen van het zakelijk recht nog andere gerelateerde zakelijkgerechtigden zijn"
         zakelijkGerechtigden:
           type: "array"
           items:


### PR DESCRIPTION
Bij het doorvoeren vroeg ik mij af of ik nu bij de zakelijk gerechtigde_links ook een link moet opnemen naar het appartementsrecht waar het gesplitste recht van de zakelijkgerechtigde betrekking op heeft. Anders heb je nergens een verwijzing naar het gesplitste appartementsrecht. 

Ik heb nu allen doorgevoerd wat we besproken hebben. Bovenstaande link is dus nog niet opgenomen. 