### PR TITLE
Aanpassingen documentatie m.b.t. 1.5 versie

### DIFF
--- a/.github/workflows/generate-user-stories.yml
+++ b/.github/workflows/generate-user-stories.yml
@@ -17,11 +17,11 @@ jobs:
           echo -e '---\nlayout: page-with-side-nav\ntitle: User Stories in Ontwikkeling\n---\n' >> user-stories-dev.md
           echo -e '# User stories\n' >> user-stories-dev.md
 
-      - name: List 'v1.5' user stories
+      - name: List 'v2.0' user stories
         uses: lee-dohm/select-matching-issues@v1.2.0
         with:
           format: list
-          query:  label:"v1.5" label:"User Story"
+          query:  label:"v2.0" label:"User Story"
           token: ${{ secrets.GITHUB_TOKEN }}
           path: issues-tmp.md
       - run: |
@@ -33,6 +33,18 @@ jobs:
           echo -e '---\nlayout: page-with-side-nav\ntitle: User Stories in Productie\n---\n' >> user-stories-prod.md
           echo -e '# User stories\n' >> user-stories-prod.md
           
+      - name: List 'v1.5' user stories
+        uses: lee-dohm/select-matching-issues@v1.2.0
+        with:
+          format: list
+          query:  label:"v1.5" label:"User Story"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: issues-tmp.md
+      - run: |
+          echo -e '## Vanaf versie 1.5\n' >> user-stories-prod.md
+          cat issues-tmp.md >> user-stories-prod.md
+          echo -e '\n' >> user-stories-prod.md
+        
       - name: List 'v1.4' user stories
         uses: lee-dohm/select-matching-issues@v1.2.0
         with:

--- a/.github/workflows/generate-user-stories.yml
+++ b/.github/workflows/generate-user-stories.yml
@@ -17,11 +17,11 @@ jobs:
           echo -e '---\nlayout: page-with-side-nav\ntitle: User Stories in Ontwikkeling\n---\n' >> user-stories-dev.md
           echo -e '# User stories\n' >> user-stories-dev.md
 
-      - name: List 'v2.0' user stories
+      - name: List 'v1.6' user stories
         uses: lee-dohm/select-matching-issues@v1.2.0
         with:
           format: list
-          query:  label:"v2.0" label:"User Story"
+          query:  label:"v1.6" label:"User Story"
           token: ${{ secrets.GITHUB_TOKEN }}
           path: issues-tmp.md
       - run: |

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 
 API voor het zoeken en raadplegen van gegevens uit de Basisregistratie Kadaster (BRK).
 
-## BRK bevragen v1.4.1 is live!
+## Haal Centraal BRK bevragen v1.5 is live!
 
 BRK bevragen levert nu ook:
-* inzicht in de filiatie van Kadastraal onroerende zaken
-* zoeken in relatie tot gorzen en aanwassen
+* eigenaren van de appartementsrechten die uit erfpacht zijn ontstaan. 
+* een indicatie sluimerend op appartementsrechten als deze niet vervallen maar gesplitst zijn.
 
 Bekijk de [release notes](https://vng-realisatie.github.io/Haal-Centraal-BRK-bevragen/releasenotes).
 
@@ -26,7 +26,7 @@ Bekijk de [release notes](https://vng-realisatie.github.io/Haal-Centraal-BRK-bev
 Komende periode wordt de API uitgebreid met andere erfpachters. Dat zijn de eigenaren van de appartementsrechten die uit erfpacht zijn ontstaan. Ook worden sluimerende appartementsrechten zichtbaar gemaakt (v1.5).
 We doen ons uiterste best om de API evolvable door te ontwikkelen en geen breaking changes te introduceren.
 
-* Bekijk de [voortgang van issues en user stories](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/issues?q=is%3Aissue+label%3A%22v1.5%22+label%3A%22User+Story%22)
+* Bekijk de [voortgang van issues en user stories](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/issues?q=is%3Aissue+label%3A%22v2.0%22+label%3A%22User+Story%22)
 * Bekijk de specificaties in ontwikkeling met [Swagger UI](https://vng-realisatie.github.io/Haal-Centraal-BRK-bevragen/swagger-ui-io) of [Redoc](https://vng-realisatie.github.io/Haal-Centraal-BRK-bevragen/redoc-io)
 
 ## Bronnen

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ API voor het zoeken en raadplegen van gegevens uit de Basisregistratie Kadaster 
 ## Haal Centraal BRK bevragen v1.5 is live!
 
 BRK bevragen levert nu ook:
-* eigenaren van de appartementsrechten die uit erfpacht zijn ontstaan. 
+* gesplitste zakelijke rechten en de houders van deze rechten. 
 * een indicatie sluimerend op appartementsrechten als deze niet vervallen maar gesplitst zijn.
+* altijd gesplitstZakelijkRecht bij een Kadastraal onroerende zaak, ook als daar niet om gevraagd wordt.
 
 Bekijk de [release notes](https://vng-realisatie.github.io/Haal-Centraal-BRK-bevragen/releasenotes).
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,7 @@ Bekijk de [release notes](https://vng-realisatie.github.io/Haal-Centraal-BRK-bev
 
 ## Doorontwikkeling van de BRK bevragen API
 
-Komende periode wordt de API uitgebreid met andere erfpachters. Dat zijn de eigenaren van de appartementsrechten die uit erfpacht zijn ontstaan. Ook worden sluimerende appartementsrechten zichtbaar gemaakt (v1.5).
-We doen ons uiterste best om de API evolvable door te ontwikkelen en geen breaking changes te introduceren.
-
-* Bekijk de [voortgang van issues en user stories](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/issues?q=is%3Aissue+label%3A%22v2.0%22+label%3A%22User+Story%22)
-* Bekijk de specificaties in ontwikkeling met [Swagger UI](https://vng-realisatie.github.io/Haal-Centraal-BRK-bevragen/swagger-ui-io) of [Redoc](https://vng-realisatie.github.io/Haal-Centraal-BRK-bevragen/redoc-io)
+Komende periode wordt de API niet actief doorontwikkeld, bugs worden wel opgelost. Mis je iets? Geef dat wel aan ons door! Per 1 juli gaan we weer aan de slag, onder andere met het toevoegen van historie.
 
 ## Bronnen
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -25,7 +25,7 @@ nav:
         path: /redoc
       - title: Features
         path: /features
-  - title: Specificaties v. 2.0 (IO)
+  - title: Specificaties v. 1.6 (IO)
     subnav:
       - title: User stories
         path: /user-stories-dev

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -13,12 +13,11 @@ nav:
         path: /
       - title: Goals canvas
         path: /goals-canvas
-  - title: Specificaties v. 1.4.1 (Live)
+  - title: Specificaties v. 1.5 (Live)
     subnav:
       - title: Getting started
         path: /getting-started
       - title: User stories
-#        url: https://vng-realisatie.github.io/Haal-Centraal-BRK-bevragen/user-stories-prod
         path: /user-stories-prod
       - title: Bevragen API (swagger-ui)
         path: /swagger-ui
@@ -26,17 +25,14 @@ nav:
         path: /redoc
       - title: Features
         path: /features
-  - title: Specificaties v. 1.5 (IO)
+  - title: Specificaties v. 2.0 (IO)
     subnav:
       - title: User stories
-#        url: https://vng-realisatie.github.io/Haal-Centraal-BRK-bevragen/user-stories-dev
         path: /user-stories-dev
       - title: Bevragen API (swagger-ui)
         path: /swagger-ui-io
       - title: Bevragen API (redoc)
         path: /redoc-io
-#      - title: Features
-#        path: /features
 plugins:
   - jekyll-redirect-from
   - jekyll-remote-theme

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -348,6 +348,27 @@ Onderstaande tabellen bevatten testgevallen voor specifieke situaties waarmee de
 		<td> </td>
 		<td>vervallen perceel</td>
 	</tr>
+	<tr>
+		<td>Gesplitst zakelijkRecht</td>
+		<td>59020139970000<br/>Groningen P 1399</td>
+		<td> </td>
+		<td> </td>
+		<td>recht van erfpacht is gesplitst</td>
+	</tr>
+	<tr>
+		<td>Gesplitst zakelijkRecht</td>
+		<td>59020140010001<br/>Groningen P 1400 A1</td>
+		<td> </td>
+		<td> </td>
+		<td> </td>
+	</tr>
+	<tr>
+		<td>Gesplitst zakelijkRecht</td>
+		<td>59020140010002<br/>Groningen P 1400 A2</td>
+		<td> </td>
+		<td> </td>
+		<td> </td>
+	</tr>
 
 </table>
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -134,17 +134,10 @@ We hebben al een [Postman collection](https://github.com/VNG-Realisatie/Haal-Cen
 
 De testomgeving van de API is te benaderen via de volgende urls:
 - _Beveiligde verbinding met alleen API-key: https://api.brk.kadaster.nl/esd-eto-apikey/bevragen/v1/_
-    - Voor deze connectie met de testomgeving van deze API is vereist:
-        - Een geldige API-key. Deze wordt bij de request opgenomen in request header "X-Api-Key". Wanneer je je aanmeldt voor het gebruiken van de API ontvang je de API-key.
 
 - _Beveiligde verbinding met API-key & mTLS: https://api.brk.kadaster.nl/esd-eto/bevragen/v1/_
-    - Voor deze connectie met de testomgeving van deze API is vereist:
-        - Een geldige API-key. Deze wordt bij de request opgenomen in request header "X-Api-Key". Wanneer je je aanmeldt voor het gebruiken van de API ontvang je de API-key.
-        - Internet toegang tot het Kadaster endpoint via IPv4 of IPv6 en met het TLS 1.2 protocol.
-        - Een Staat der Nederlanden root CA - G3 certificaat in de truststore, zie hiervoor: https://www.pkioverheid.nl/
-        - Een geldig PKIoverheid client certificaat met SERIALNUMMER=<eigen-OIN-nummer> in de keystore dat deel uitmaakt van de Staat der Nederlanden - G3 hiërarchie,
-zie hiervoor: https://www.logius.nl/diensten/pkioverheid
-        - Een mutual TLS endpoint configuratie, waarbij de TLS verbinding met het Kadaster alleen tot stand mag en kan komen als er bij het opzetten van de verbinding een wederzijds vertrouwen op basis van de PKIoverheid certificaten hiërarchie bestaat.
+
+Vraag hiervoor een [API-key en PKI-overheidscertificaat](https://www.kadaster.nl/zakelijk/producten/eigendom/brk-bevragen) aan.
 
 ### Testgevallen
 Onderstaande tabellen bevatten testgevallen voor specifieke situaties waarmee de werking van de API kan worden getest op de test omgeving. Meer details over welke testdata in de testgevallen zit, vind je in [test cases](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/tree/master/test/cases)
@@ -410,13 +403,7 @@ Onderstaande tabellen bevatten testgevallen voor specifieke situaties waarmee de
 </table>
 
 ## Aansluiten op productie
-Voor de connectie met de productieomgeving van deze API is vereist:
-- Een geldige API-key. Deze wordt bij de request opgenomen in request header "X-Api-Key". Wanneer je je aanmeldt voor het gebruiken van de API ontvang je de API-key.
-- Internet toegang tot het Kadaster endpoint via IPv4 of IPv6 en met het TLS 1.2 protocol.
-- Een Staat der Nederlanden root CA - G3 certificaat in de truststore, zie hiervoor: https://www.pkioverheid.nl/
-- Een geldig PKIoverheid client certificaat met SERIALNUMMER=<eigen-OIN-nummer> in de keystore dat deel uitmaakt van de Staat der Nederlanden - G3 hiërarchie,
-zie hiervoor: https://www.logius.nl/diensten/pkioverheid
-- Een mutual TLS endpoint configuratie, waarbij de TLS verbinding met het Kadaster alleen tot stand mag en kan komen als er bij het opzetten van de verbinding een wederzijds vertrouwen op basis van de PKIoverheid certificaten hiërarchie bestaat.
+Vraag voor het aansluiten op de productie omgeving een [API-key en PKI-overheidscertificaat](https://www.kadaster.nl/zakelijk/producten/eigendom/brk-bevragen) aan.
 
 ### URL
 De productieomgeving van de API is te benaderen via de volgende url: https://api.brk.kadaster.nl/esd/bevragen/v1/

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,11 +10,12 @@ title: Haal Centraal BRK bevragingen
 
 API voor het zoeken en raadplegen van gegevens uit de Basisregistratie Kadaster (BRK).
 
-## BRK bevragen v1.4.1 is live!
+## Haal Centraal BRK bevragen v1.5 is live!
 
 BRK bevragen levert nu ook:
-* inzicht in de filiatie van Kadastraal onroerende zaken
-* zoeken in relatie tot gorzen en aanwassen
+* eigenaren van de appartementsrechten die uit erfpacht zijn ontstaan. 
+* een indicatie sluimerend op appartementsrechten als deze niet vervallen maar gesplitst zijn.
+* altijd gesplitstZakelijkRecht bij een Kadastraal onroerende zaak, ook als daar niet om gevraagd wordt.
 
 Bekijk de [release notes](./releasenotes).
 
@@ -29,7 +30,7 @@ Bekijk de [release notes](./releasenotes).
 ## Doorontwikkeling van de BRK bevragen API
 
 Komende periode wordt de API uitgebreid met andere erfpachters. Dat zijn de eigenaren van de appartementsrechten die uit erfpacht zijn ontstaan. Ook worden sluimerende appartementsrechten zichtbaar gemaakt (v1.5).
-* Bekijk de [voortgang van issues en user stories](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/issues?q=is%3Aissue+label%3A%22v1.5%22+label%3A%22User+Story%22){:target="_blank" rel="noopener"}
+* Bekijk de [voortgang van issues en user stories](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/issues?q=is%3Aissue+label%3A%22v2.0%22+label%3A%22User+Story%22){:target="_blank" rel="noopener"}
 * Bekijk de specificaties in ontwikkeling met [Swagger UI](./swagger-ui-io) of [Redoc](./redoc-io)
 
 ## Bronnen

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,9 +29,7 @@ Bekijk de [release notes](./releasenotes).
 
 ## Doorontwikkeling van de BRK bevragen API
 
-Komende periode wordt de API uitgebreid met andere erfpachters. Dat zijn de eigenaren van de appartementsrechten die uit erfpacht zijn ontstaan. Ook worden sluimerende appartementsrechten zichtbaar gemaakt (v1.5).
-* Bekijk de [voortgang van issues en user stories](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/issues?q=is%3Aissue+label%3A%22v1.6%22+label%3A%22User+Story%22){:target="_blank" rel="noopener"}
-* Bekijk de specificaties in ontwikkeling met [Swagger UI](./swagger-ui-io) of [Redoc](./redoc-io)
+Komende periode wordt de API niet actief doorontwikkeld, bugs worden wel opgelost. Mis je iets? Geef dat wel aan ons door! Per 1 juli gaan we weer aan de slag, onder andere met het toevoegen van historie.
 
 ## Bronnen
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ Bekijk de [release notes](./releasenotes).
 ## Doorontwikkeling van de BRK bevragen API
 
 Komende periode wordt de API uitgebreid met andere erfpachters. Dat zijn de eigenaren van de appartementsrechten die uit erfpacht zijn ontstaan. Ook worden sluimerende appartementsrechten zichtbaar gemaakt (v1.5).
-* Bekijk de [voortgang van issues en user stories](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/issues?q=is%3Aissue+label%3A%22v2.0%22+label%3A%22User+Story%22){:target="_blank" rel="noopener"}
+* Bekijk de [voortgang van issues en user stories](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/issues?q=is%3Aissue+label%3A%22v1.6%22+label%3A%22User+Story%22){:target="_blank" rel="noopener"}
 * Bekijk de specificaties in ontwikkeling met [Swagger UI](./swagger-ui-io) of [Redoc](./redoc-io)
 
 ## Bronnen

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ API voor het zoeken en raadplegen van gegevens uit de Basisregistratie Kadaster 
 ## Haal Centraal BRK bevragen v1.5 is live!
 
 BRK bevragen levert nu ook:
-* eigenaren van de appartementsrechten die uit erfpacht zijn ontstaan. 
+* gesplitste zakelijke rechten en de houders van deze rechten. 
 * een indicatie sluimerend op appartementsrechten als deze niet vervallen maar gesplitst zijn.
 * altijd gesplitstZakelijkRecht bij een Kadastraal onroerende zaak, ook als daar niet om gevraagd wordt.
 

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -5,6 +5,39 @@ title: Haal Centraal BRK bevragingen
 
 # Release notes BRK-Bevragen
 
+## **Versie 1.5.0:**
+
+### User stories
+
+- [882](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/issues/882){:target="_blank"}): Als medewerker Erfpacht wil ik weten wie de eigenaren zijn van appartementsrechten die uit erfpacht zijn ontstaan
+- [843](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/issues/843){:target="_blank"}): Als medewerker en ontwikkelaar wil ik dat niet vervallen maar wel gesplitste appartementsrechten een indicatie Sluimerend krijgen
+
+### Openapi.yaml
+
+- Endpoint /kadastraalonroerendezaken:
+  - inclusiefKadastraalOnroerendeZakenUitSplitsing toegevoegd als queryparameter aan /kadastraalonroerendezaken
+- Component ZakelijkGerechtigdeHalCollectie:
+    - Properties toegevoegd:
+      - gesplitstZakelijkRecht
+      - _links.kadastraalOnroerendeZakenUitSplitsing
+      - _links.kadastraalOnroerendeZakenUitSplitsingInclusiefZakelijkGerechtigden
+- Component KadastraalOnroerendeZaak:
+  - Properties toegevoegd:
+    - gesplitstZakelijkRecht
+    - indicatieSluimerend
+- Component AppartementsrechtBasis:
+  - Properties toegevoegd:
+    - indicatieSluimerend
+
+### Features:
+
+De volgende feature is toegevoegd:
+- gesplitst-zakelijk-recht.feature
+
+### Issues
+
+Alle issues die in deze release zijn opgelost hebben in de issues-lijst het label "v1.5" gekregen. Door op dit label te filteren in de (gesloten) issues is een gedetailleerd overzicht van wijzigingen en bug-fixes te krijgen.
+
 
 ## **Versie 1.4.1:**
 


### PR DESCRIPTION
Bevat voornl. aanpassingen t.b.v. de GitHub Pages omgeving.

Graag aandacht voor:
* In zowel README.md en index.md staat de zin<br/><br/>_"Komende periode wordt de API uitgebreid met andere erfpachters. Dat zijn de eigenaren van de appartementsrechten die uit erfpacht zijn ontstaan. Ook worden sluimerende appartementsrechten zichtbaar gemaakt (v1.5)."_<br/><br/>Deze moet vervangen worden zodat duidelijk is wat men straks in de 2.0 kan verwachten.
* getting-started.md
  Ik heb het idee dat de beschikbare resources niet zijn gewijzigd maar graag een check daarop.
  Ook de testgevallen moeten wellicht aangepast worden.
* goals-canvas.md moet wellicht worden aangepast.
* releasenotes.md moeten worden aangepast.