### PR TITLE
Correctie op links en teksten

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Komende periode wordt de API niet actief doorontwikkeld, bugs worden wel opgelos
 * [API Design Visie](https://github.com/Geonovum/KP-APIs/blob/master/overleggen/Werkgroep%20API%20design%20visie/API%20Design%20Visie.md){:target="_blank" rel="noopener"}
 * [REST API Design Rules](https://docs.geostandaarden.nl/api/API-Designrules/){:target="_blank" rel="noopener"}
 * [Landelijke API strategie voor de overheid](https://geonovum.github.io/KP-APIs/){:target="_blank" rel="noopener"}
-* [Stelselcatalogus](https://www.stelselcatalogus.nl/registraties/BRK/){:target="_blank" rel="noopener"}
+* [Stelselcatalogus](https://www.stelselcatalogus.nl/registraties/registratie?id=http://opendata.stelselcatalogus.nl/id/registratie/BRK){:target="_blank" rel="noopener"}
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ API voor het zoeken en raadplegen van gegevens uit de Basisregistratie Kadaster 
 
 Vanaf 14 september 2023 geldt versie 2.0 als de nieuwe standaard. Deze versie levert geen nieuwe functionaliteit wel zijn enkele bugs opgelost. Versie 1.5 van de standaard wordt na 15 maart 2024 niet meer ondersteund.
 
-Bekijk de [release notes]([./releasenotes](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/blob/Check-op-links-en-teksten/docs/releasenotes.md)) voor de in deze versie opgeloste bugs.
+Bekijk de [release notes](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/blob/Check-op-links-en-teksten/docs/releasenotes.md) voor de in deze versie opgeloste bugs.
 
 ## Direct aan de slag?
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Bekijk de [release notes]([./releasenotes](https://github.com/VNG-Realisatie/Haa
 
 * Bekijk de specificaties met [Swagger UI](https://vng-realisatie.github.io/Haal-Centraal-BRK-bevragen/swagger-ui-2.0) of [Redoc](https://vng-realisatie.github.io/Haal-Centraal-BRK-bevragen/redoc-2.0)
 * Lees de [Getting started](https://vng-realisatie.github.io/Haal-Centraal-BRK-bevragen/getting-started)
-* Download de [technische specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/blob/master/specificatie/genereervariant/openapi.yaml){:target="_blank" rel="noopener"}
-* [Vraag een API-key aan](https://formulieren.kadaster.nl/aanmelden_brk_bevragen){:target="_blank" rel="noopener"} voor toegang tot de testomgeving.
+* Download de [technische specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/blob/master/specificatie/genereervariant/openapi.yaml)
+* [Vraag een API-key aan](https://formulieren.kadaster.nl/aanmelden_brk_bevragen) voor toegang tot de testomgeving.
 
 ## Doorontwikkeling van de BRK bevragen API
 
@@ -24,10 +24,10 @@ Komende periode wordt de API niet actief doorontwikkeld, bugs worden wel opgelos
 
 ## Bronnen
 
-* [API Design Visie](https://github.com/Geonovum/KP-APIs/blob/master/overleggen/Werkgroep%20API%20design%20visie/API%20Design%20Visie.md){:target="_blank" rel="noopener"}
-* [REST API Design Rules](https://docs.geostandaarden.nl/api/API-Designrules/){:target="_blank" rel="noopener"}
-* [Landelijke API strategie voor de overheid](https://geonovum.github.io/KP-APIs/){:target="_blank" rel="noopener"}
-* [Stelselcatalogus](https://www.stelselcatalogus.nl/registraties/registratie?id=http://opendata.stelselcatalogus.nl/id/registratie/BRK){:target="_blank" rel="noopener"}
+* [API Design Visie](https://github.com/Geonovum/KP-APIs/blob/master/overleggen/Werkgroep%20API%20design%20visie/API%20Design%20Visie.md)
+* [REST API Design Rules](https://docs.geostandaarden.nl/api/API-Designrules/)
+* [Landelijke API strategie voor de overheid](https://geonovum.github.io/KP-APIs/)
+* [Stelselcatalogus](https://www.stelselcatalogus.nl/registraties/registratie?id=http://opendata.stelselcatalogus.nl/id/registratie/BRK)
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ API voor het zoeken en raadplegen van gegevens uit de Basisregistratie Kadaster 
 
 Vanaf 14 september 2023 geldt versie 2.0 als de nieuwe standaard. Deze versie levert geen nieuwe functionaliteit wel zijn enkele bugs opgelost. Versie 1.5 van de standaard wordt na 15 maart 2024 niet meer ondersteund.
 
-Bekijk de [release notes]([./releasenotes](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/blob/Check-op-links-en-teksten/docs/releasenotes.md)) voor de in deze versie opgeloste bugs of bezoek de [GitHub repository](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/).
+Bekijk de [release notes]([./releasenotes](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/blob/Check-op-links-en-teksten/docs/releasenotes.md)) voor de in deze versie opgeloste bugs.
 
 ## Direct aan de slag?
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ API voor het zoeken en raadplegen van gegevens uit de Basisregistratie Kadaster 
 
 Vanaf 14 september 2023 geldt versie 2.0 als de nieuwe standaard. Deze versie levert geen nieuwe functionaliteit wel zijn enkele bugs opgelost. Versie 1.5 van de standaard wordt na 15 maart 2024 niet meer ondersteund.
 
-Bekijk de [release notes](./releasenotes) voor de in deze versie opgeloste bugs of bezoek de [GitHub repository](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/).
+Bekijk de [release notes]([./releasenotes](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/blob/Check-op-links-en-teksten/docs/releasenotes.md)) voor de in deze versie opgeloste bugs of bezoek de [GitHub repository](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/).
 
 ## Direct aan de slag?
 
-* Bekijk de specificaties met [Swagger UI](./swagger-ui-2.0) of [Redoc](./redoc-2.0)
-* Lees de [Getting started](./getting-started)
+* Bekijk de specificaties met [Swagger UI](https://vng-realisatie.github.io/Haal-Centraal-BRK-bevragen/swagger-ui-2.0) of [Redoc](https://vng-realisatie.github.io/Haal-Centraal-BRK-bevragen/redoc-2.0)
+* Lees de [Getting started](https://vng-realisatie.github.io/Haal-Centraal-BRK-bevragen/getting-started)
 * Download de [technische specificaties](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/blob/master/specificatie/genereervariant/openapi.yaml){:target="_blank" rel="noopener"}
 * [Vraag een API-key aan](https://formulieren.kadaster.nl/aanmelden_brk_bevragen){:target="_blank" rel="noopener"} voor toegang tot de testomgeving.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -118,7 +118,8 @@ Note. De prerequisite van OpenAPI Generator is JAVA. Je moet een JAVA runtime in
 
 ## Probeer en test de API
 De werking van de API is het makkelijkst te testen met behulp van [Postman](https://www.getpostman.com/).
-We hebben al een [Postman collection](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/blob/master/test/BRK-Bevragen-postman-collection.json){:target="_blank" rel="noopener"} voor je klaargezet. Deze kun je importeren in Postman.
+De [openapi.yaml](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/blob/master/specificatie/genereervariant/openapi.yaml){:target="_blank"} kun je importeren als project, waarna de verschillende requests worden ingeladen die deze API ondersteunt.
+Je kunt ook het project dat we voor je heben gemaakt gebruiken: [BRK-Bevragen-postman-collection.json](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/blob/master/test/BRK-Bevragen-postman-collection.json){:target="_blank"}. Hierin moet je alleen de base url en authenticatie (API-key) nog invullen.
 
 ### Configureer de url en api key
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -118,7 +118,6 @@ Note. De prerequisite van OpenAPI Generator is JAVA. Je moet een JAVA runtime in
 
 ## Probeer en test de API
 De werking van de API is het makkelijkst te testen met behulp van [Postman](https://www.getpostman.com/).
-We hebben al een project voor je gemaakt die je kan gebruiken: [BRK-Bevragen-postman-collection.json](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/blob/master/test/BRK-Bevragen-postman-collection.json). Hierin moet je alleen de endpoints en authenticatie (API-key) nog invullen.
 We hebben al een [Postman collection](https://github.com/VNG-Realisatie/Haal-Centraal-BRK-bevragen/blob/master/test/BRK-Bevragen-postman-collection.json){:target="_blank" rel="noopener"} voor je klaargezet. Deze kun je importeren in Postman.
 
 ### Configureer de url en api key

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ Komende periode wordt de API niet actief doorontwikkeld, bugs worden wel opgelos
 * [API Design Visie](https://github.com/Geonovum/KP-APIs/blob/master/overleggen/Werkgroep%20API%20design%20visie/API%20Design%20Visie.md){:target="_blank" rel="noopener"}
 * [REST API Design Rules](https://docs.geostandaarden.nl/api/API-Designrules/){:target="_blank" rel="noopener"}
 * [Landelijke API strategie voor de overheid](https://geonovum.github.io/KP-APIs/){:target="_blank" rel="noopener"}
-* [Stelselcatalogus](https://www.stelselcatalogus.nl/registraties/BRK/){:target="_blank" rel="noopener"}
+* [Stelselcatalogus](https://www.stelselcatalogus.nl/registraties/registratie?id=http://opendata.stelselcatalogus.nl/id/registratie/BRK){:target="_blank" rel="noopener"}
 
 ## Contact
 


### PR DESCRIPTION
O.a.:

* Check op links en teksten
  - In README.md
    - Geen individuele e-Mailadressen meer in de 'Contacten' paragraaf;
    - Inhoud gelijk gemaakt aan 'index.md' (main pagina van GitHub Pages);
  - index.md (main pagina van GitHub Pages)
    - De link 'Stelselcatalogus' werkte niet meer. Deze verwees naar:<br/><br/>*https://www.stelselcatalogus.nl/registraties/BRK/*<br/><br/>maar moet waarschijnlijk verwijzen naar:<br/><br/>*https://www.stelselcatalogus.nl/registraties/registratie?id=http://opendata.stelselcatalogus.nl/id/registratie/BRK*<br/><br/>Dit heb ik in deze PR aangepast maar graag even aangeven of dit klopt;
  - Getting Started
    - Onder 'Probeer en test de API' staat de tekst:<br/><br/>*We hebben al een project voor je gemaakt die je kan gebruiken: BRK-Bevragen-postman-collection.json. Hierin moet je alleen de endpoints en authenticatie (API-key) nog invullen. We hebben al een Postman collection voor je klaargezet. Deze kun je importeren in Postman.*<br/><br/>Deze alinea heb ik getracht wat duidelijker te maken.

**LET OP**
- [ ] Wijzig na mergen van dit PR ook de 'develop' branch.